### PR TITLE
Fix Go type name initialisms

### DIFF
--- a/examples/authenticated-api/echo/api/api.gen.go
+++ b/examples/authenticated-api/echo/api/api.gen.go
@@ -44,7 +44,7 @@ type ThingWithID struct {
 	// Embedded struct due to allOf(#/components/schemas/Thing)
 	Thing `yaml:",inline"`
 	// Embedded fields due to inline allOf schema
-	Id int64 `json:"id"`
+	ID int64 `json:"id"`
 }
 
 // AddThingJSONBody defines parameters for AddThing.
@@ -293,7 +293,7 @@ type ClientWithResponsesInterface interface {
 type ListThingsResponse struct {
 	Body         []byte
 	HTTPResponse *http.Response
-	JSON200      *[]ThingWithID
+	JSON         *[]ThingWithID
 }
 
 // Status returns HTTPResponse.Status
@@ -315,7 +315,7 @@ func (r ListThingsResponse) StatusCode() int {
 type AddThingResponse struct {
 	Body         []byte
 	HTTPResponse *http.Response
-	JSON201      *[]ThingWithID
+	JSON         *[]ThingWithID
 }
 
 // Status returns HTTPResponse.Status
@@ -379,7 +379,7 @@ func ParseListThingsResponse(rsp *http.Response) (*ListThingsResponse, error) {
 		if err := json.Unmarshal(bodyBytes, &dest); err != nil {
 			return nil, err
 		}
-		response.JSON200 = &dest
+		response.JSON = &dest
 
 	}
 
@@ -405,7 +405,7 @@ func ParseAddThingResponse(rsp *http.Response) (*AddThingResponse, error) {
 		if err := json.Unmarshal(bodyBytes, &dest); err != nil {
 			return nil, err
 		}
-		response.JSON201 = &dest
+		response.JSON = &dest
 
 	}
 

--- a/examples/authenticated-api/echo/server/server.go
+++ b/examples/authenticated-api/echo/server/server.go
@@ -59,7 +59,7 @@ func (s *server) ListThings(ctx echo.Context) error {
 
 	for _, key := range thingKeys {
 		thing := s.things[key]
-		things = append(things, api.ThingWithID{Thing: thing, Id: key})
+		things = append(things, api.ThingWithID{Thing: thing, ID: key})
 	}
 
 	s.RUnlock()
@@ -98,7 +98,7 @@ func (s *server) AddThing(ctx echo.Context) error {
 	s.things[s.lastID] = thing
 	thingWithId := api.ThingWithID{
 		Thing: thing,
-		Id:    s.lastID,
+		ID:    s.lastID,
 	}
 	s.lastID++
 

--- a/examples/petstore-expanded/chi/api/petstore.gen.go
+++ b/examples/petstore-expanded/chi/api/petstore.gen.go
@@ -42,7 +42,7 @@ type Pet struct {
 	NewPet `yaml:",inline"`
 	// Embedded fields due to inline allOf schema
 	// Unique id of the pet
-	Id int64 `json:"id"`
+	ID int64 `json:"id"`
 }
 
 // FindPetsParams defines parameters for FindPets.
@@ -70,10 +70,10 @@ type ServerInterface interface {
 	AddPet(w http.ResponseWriter, r *http.Request)
 	// Deletes a pet by ID
 	// (DELETE /pets/{id})
-	DeletePet(w http.ResponseWriter, r *http.Request, id int64)
+	DeletePet(w http.ResponseWriter, r *http.Request, iD int64)
 	// Returns a pet by ID
 	// (GET /pets/{id})
-	FindPetByID(w http.ResponseWriter, r *http.Request, id int64)
+	FindPetByID(w http.ResponseWriter, r *http.Request, iD int64)
 }
 
 // ServerInterfaceWrapper converts contexts to parameters.
@@ -152,9 +152,9 @@ func (siw *ServerInterfaceWrapper) DeletePet(w http.ResponseWriter, r *http.Requ
 	var err error
 
 	// ------------- Path parameter "id" -------------
-	var id int64
+	var iD int64
 
-	err = runtime.BindStyledParameter("simple", false, "id", chi.URLParam(r, "id"), &id)
+	err = runtime.BindStyledParameter("simple", false, "id", chi.URLParam(r, "id"), &iD)
 	if err != nil {
 		err = fmt.Errorf("Invalid format for parameter id: %w", err)
 		siw.ErrorHandlerFunc(w, r, &InvalidParamFormatError{err})
@@ -162,7 +162,7 @@ func (siw *ServerInterfaceWrapper) DeletePet(w http.ResponseWriter, r *http.Requ
 	}
 
 	var handler = func(w http.ResponseWriter, r *http.Request) {
-		siw.Handler.DeletePet(w, r, id)
+		siw.Handler.DeletePet(w, r, iD)
 	}
 
 	for _, middleware := range siw.HandlerMiddlewares {
@@ -179,9 +179,9 @@ func (siw *ServerInterfaceWrapper) FindPetByID(w http.ResponseWriter, r *http.Re
 	var err error
 
 	// ------------- Path parameter "id" -------------
-	var id int64
+	var iD int64
 
-	err = runtime.BindStyledParameter("simple", false, "id", chi.URLParam(r, "id"), &id)
+	err = runtime.BindStyledParameter("simple", false, "id", chi.URLParam(r, "id"), &iD)
 	if err != nil {
 		err = fmt.Errorf("Invalid format for parameter id: %w", err)
 		siw.ErrorHandlerFunc(w, r, &InvalidParamFormatError{err})
@@ -189,7 +189,7 @@ func (siw *ServerInterfaceWrapper) FindPetByID(w http.ResponseWriter, r *http.Re
 	}
 
 	var handler = func(w http.ResponseWriter, r *http.Request) {
-		siw.Handler.FindPetByID(w, r, id)
+		siw.Handler.FindPetByID(w, r, iD)
 	}
 
 	for _, middleware := range siw.HandlerMiddlewares {

--- a/examples/petstore-expanded/chi/api/petstore.go
+++ b/examples/petstore-expanded/chi/api/petstore.go
@@ -88,11 +88,11 @@ func (p *PetStore) AddPet(w http.ResponseWriter, r *http.Request) {
 	var pet Pet
 	pet.Name = newPet.Name
 	pet.Tag = newPet.Tag
-	pet.Id = p.NextId
+	pet.ID = p.NextId
 	p.NextId = p.NextId + 1
 
 	// Insert into map
-	p.Pets[pet.Id] = pet
+	p.Pets[pet.ID] = pet
 
 	// Now, we have to return the NewPet
 	w.WriteHeader(http.StatusCreated)

--- a/examples/petstore-expanded/chi/petstore_test.go
+++ b/examples/petstore-expanded/chi/petstore_test.go
@@ -61,11 +61,11 @@ func TestPetStore(t *testing.T) {
 
 	t.Run("Find pet by ID", func(t *testing.T) {
 		pet := api.Pet{
-			Id: 100,
+			ID: 100,
 		}
 
-		store.Pets[pet.Id] = pet
-		rr := doGet(t, r, fmt.Sprintf("/pets/%d", pet.Id))
+		store.Pets[pet.ID] = pet
+		rr := doGet(t, r, fmt.Sprintf("/pets/%d", pet.ID))
 
 		var resultPet api.Pet
 		err = json.NewDecoder(rr.Body).Decode(&resultPet)

--- a/examples/petstore-expanded/echo/api/petstore-server.gen.go
+++ b/examples/petstore-expanded/echo/api/petstore-server.gen.go
@@ -28,10 +28,10 @@ type ServerInterface interface {
 	AddPet(ctx echo.Context) error
 	// Deletes a pet by ID
 	// (DELETE /pets/{id})
-	DeletePet(ctx echo.Context, id int64) error
+	DeletePet(ctx echo.Context, iD int64) error
 	// Returns a pet by ID
 	// (GET /pets/{id})
-	FindPetByID(ctx echo.Context, id int64) error
+	FindPetByID(ctx echo.Context, iD int64) error
 }
 
 // ServerInterfaceWrapper converts echo contexts to parameters.
@@ -77,15 +77,15 @@ func (w *ServerInterfaceWrapper) AddPet(ctx echo.Context) error {
 func (w *ServerInterfaceWrapper) DeletePet(ctx echo.Context) error {
 	var err error
 	// ------------- Path parameter "id" -------------
-	var id int64
+	var iD int64
 
-	err = runtime.BindStyledParameterWithLocation("simple", false, "id", runtime.ParamLocationPath, ctx.Param("id"), &id)
+	err = runtime.BindStyledParameterWithLocation("simple", false, "id", runtime.ParamLocationPath, ctx.Param("id"), &iD)
 	if err != nil {
 		return echo.NewHTTPError(http.StatusBadRequest, fmt.Sprintf("Invalid format for parameter id: %s", err))
 	}
 
 	// Invoke the callback with all the unmarshalled arguments
-	err = w.Handler.DeletePet(ctx, id)
+	err = w.Handler.DeletePet(ctx, iD)
 	return err
 }
 
@@ -93,15 +93,15 @@ func (w *ServerInterfaceWrapper) DeletePet(ctx echo.Context) error {
 func (w *ServerInterfaceWrapper) FindPetByID(ctx echo.Context) error {
 	var err error
 	// ------------- Path parameter "id" -------------
-	var id int64
+	var iD int64
 
-	err = runtime.BindStyledParameterWithLocation("simple", false, "id", runtime.ParamLocationPath, ctx.Param("id"), &id)
+	err = runtime.BindStyledParameterWithLocation("simple", false, "id", runtime.ParamLocationPath, ctx.Param("id"), &iD)
 	if err != nil {
 		return echo.NewHTTPError(http.StatusBadRequest, fmt.Sprintf("Invalid format for parameter id: %s", err))
 	}
 
 	// Invoke the callback with all the unmarshalled arguments
-	err = w.Handler.FindPetByID(ctx, id)
+	err = w.Handler.FindPetByID(ctx, iD)
 	return err
 }
 

--- a/examples/petstore-expanded/echo/api/petstore-types.gen.go
+++ b/examples/petstore-expanded/echo/api/petstore-types.gen.go
@@ -27,7 +27,7 @@ type Pet struct {
 	NewPet `yaml:",inline"`
 	// Embedded fields due to inline allOf schema
 	// Unique id of the pet
-	Id int64 `json:"id"`
+	ID int64 `json:"id"`
 }
 
 // FindPetsParams defines parameters for FindPets.

--- a/examples/petstore-expanded/echo/api/petstore.go
+++ b/examples/petstore-expanded/echo/api/petstore.go
@@ -97,11 +97,11 @@ func (p *PetStore) AddPet(ctx echo.Context) error {
 	var pet Pet
 	pet.Name = newPet.Name
 	pet.Tag = newPet.Tag
-	pet.Id = p.NextId
+	pet.ID = p.NextId
 	p.NextId = p.NextId + 1
 
 	// Insert into map
-	p.Pets[pet.Id] = pet
+	p.Pets[pet.ID] = pet
 
 	// Now, we have to return the NewPet
 	err = ctx.JSON(http.StatusCreated, pet)

--- a/examples/petstore-expanded/echo/petstore_test.go
+++ b/examples/petstore-expanded/echo/petstore_test.go
@@ -77,7 +77,7 @@ func TestPetStore(t *testing.T) {
 	assert.Equal(t, *newPet.Tag, *resultPet.Tag)
 
 	// This is the Id of the pet we inserted.
-	petId := resultPet.Id
+	petId := resultPet.ID
 
 	// Test the getter function.
 	result = testutil.NewRequest().Get(fmt.Sprintf("/pets/%d", petId)).WithAcceptJson().Go(t, e)
@@ -107,7 +107,7 @@ func TestPetStore(t *testing.T) {
 	// sure that its fields match.
 	err = result.UnmarshalBodyToObject(&resultPet)
 	assert.NoError(t, err, "error unmarshaling response")
-	petId2 := resultPet.Id
+	petId2 := resultPet.ID
 
 	// Now, list all pets, we should have two
 	result = testutil.NewRequest().Get("/pets").WithAcceptJson().Go(t, e)

--- a/examples/petstore-expanded/petstore-client.gen.go
+++ b/examples/petstore-expanded/petstore-client.gen.go
@@ -41,7 +41,7 @@ type Pet struct {
 	NewPet `yaml:",inline"`
 	// Embedded fields due to inline allOf schema
 	// Unique id of the pet
-	Id int64 `json:"id"`
+	ID int64 `json:"id"`
 }
 
 // FindPetsParams defines parameters for FindPets.
@@ -141,10 +141,10 @@ type ClientInterface interface {
 	AddPet(ctx context.Context, body AddPetJSONRequestBody, reqEditors ...RequestEditorFn) (*http.Response, error)
 
 	// DeletePet request
-	DeletePet(ctx context.Context, id int64, reqEditors ...RequestEditorFn) (*http.Response, error)
+	DeletePet(ctx context.Context, iD int64, reqEditors ...RequestEditorFn) (*http.Response, error)
 
 	// FindPetByID request
-	FindPetByID(ctx context.Context, id int64, reqEditors ...RequestEditorFn) (*http.Response, error)
+	FindPetByID(ctx context.Context, iD int64, reqEditors ...RequestEditorFn) (*http.Response, error)
 }
 
 func (c *Client) FindPets(ctx context.Context, params *FindPetsParams, reqEditors ...RequestEditorFn) (*http.Response, error) {
@@ -183,8 +183,8 @@ func (c *Client) AddPet(ctx context.Context, body AddPetJSONRequestBody, reqEdit
 	return c.Client.Do(req)
 }
 
-func (c *Client) DeletePet(ctx context.Context, id int64, reqEditors ...RequestEditorFn) (*http.Response, error) {
-	req, err := NewDeletePetRequest(c.Server, id)
+func (c *Client) DeletePet(ctx context.Context, iD int64, reqEditors ...RequestEditorFn) (*http.Response, error) {
+	req, err := NewDeletePetRequest(c.Server, iD)
 	if err != nil {
 		return nil, err
 	}
@@ -195,8 +195,8 @@ func (c *Client) DeletePet(ctx context.Context, id int64, reqEditors ...RequestE
 	return c.Client.Do(req)
 }
 
-func (c *Client) FindPetByID(ctx context.Context, id int64, reqEditors ...RequestEditorFn) (*http.Response, error) {
-	req, err := NewFindPetByIDRequest(c.Server, id)
+func (c *Client) FindPetByID(ctx context.Context, iD int64, reqEditors ...RequestEditorFn) (*http.Response, error) {
+	req, err := NewFindPetByIDRequest(c.Server, iD)
 	if err != nil {
 		return nil, err
 	}
@@ -311,12 +311,12 @@ func NewAddPetRequestWithBody(server string, contentType string, body io.Reader)
 }
 
 // NewDeletePetRequest generates requests for DeletePet
-func NewDeletePetRequest(server string, id int64) (*http.Request, error) {
+func NewDeletePetRequest(server string, iD int64) (*http.Request, error) {
 	var err error
 
 	var pathParam0 string
 
-	pathParam0, err = runtime.StyleParamWithLocation("simple", false, "id", runtime.ParamLocationPath, id)
+	pathParam0, err = runtime.StyleParamWithLocation("simple", false, "id", runtime.ParamLocationPath, iD)
 	if err != nil {
 		return nil, err
 	}
@@ -345,12 +345,12 @@ func NewDeletePetRequest(server string, id int64) (*http.Request, error) {
 }
 
 // NewFindPetByIDRequest generates requests for FindPetByID
-func NewFindPetByIDRequest(server string, id int64) (*http.Request, error) {
+func NewFindPetByIDRequest(server string, iD int64) (*http.Request, error) {
 	var err error
 
 	var pathParam0 string
 
-	pathParam0, err = runtime.StyleParamWithLocation("simple", false, "id", runtime.ParamLocationPath, id)
+	pathParam0, err = runtime.StyleParamWithLocation("simple", false, "id", runtime.ParamLocationPath, iD)
 	if err != nil {
 		return nil, err
 	}
@@ -430,16 +430,16 @@ type ClientWithResponsesInterface interface {
 	AddPetWithResponse(ctx context.Context, body AddPetJSONRequestBody, reqEditors ...RequestEditorFn) (*AddPetResponse, error)
 
 	// DeletePet request
-	DeletePetWithResponse(ctx context.Context, id int64, reqEditors ...RequestEditorFn) (*DeletePetResponse, error)
+	DeletePetWithResponse(ctx context.Context, iD int64, reqEditors ...RequestEditorFn) (*DeletePetResponse, error)
 
 	// FindPetByID request
-	FindPetByIDWithResponse(ctx context.Context, id int64, reqEditors ...RequestEditorFn) (*FindPetByIDResponse, error)
+	FindPetByIDWithResponse(ctx context.Context, iD int64, reqEditors ...RequestEditorFn) (*FindPetByIDResponse, error)
 }
 
 type FindPetsResponse struct {
 	Body         []byte
 	HTTPResponse *http.Response
-	JSON200      *[]Pet
+	JSON         *[]Pet
 	JSONDefault  *Error
 }
 
@@ -462,7 +462,7 @@ func (r FindPetsResponse) StatusCode() int {
 type AddPetResponse struct {
 	Body         []byte
 	HTTPResponse *http.Response
-	JSON200      *Pet
+	JSON         *Pet
 	JSONDefault  *Error
 }
 
@@ -507,7 +507,7 @@ func (r DeletePetResponse) StatusCode() int {
 type FindPetByIDResponse struct {
 	Body         []byte
 	HTTPResponse *http.Response
-	JSON200      *Pet
+	JSON         *Pet
 	JSONDefault  *Error
 }
 
@@ -554,8 +554,8 @@ func (c *ClientWithResponses) AddPetWithResponse(ctx context.Context, body AddPe
 }
 
 // DeletePetWithResponse request returning *DeletePetResponse
-func (c *ClientWithResponses) DeletePetWithResponse(ctx context.Context, id int64, reqEditors ...RequestEditorFn) (*DeletePetResponse, error) {
-	rsp, err := c.DeletePet(ctx, id, reqEditors...)
+func (c *ClientWithResponses) DeletePetWithResponse(ctx context.Context, iD int64, reqEditors ...RequestEditorFn) (*DeletePetResponse, error) {
+	rsp, err := c.DeletePet(ctx, iD, reqEditors...)
 	if err != nil {
 		return nil, err
 	}
@@ -563,8 +563,8 @@ func (c *ClientWithResponses) DeletePetWithResponse(ctx context.Context, id int6
 }
 
 // FindPetByIDWithResponse request returning *FindPetByIDResponse
-func (c *ClientWithResponses) FindPetByIDWithResponse(ctx context.Context, id int64, reqEditors ...RequestEditorFn) (*FindPetByIDResponse, error) {
-	rsp, err := c.FindPetByID(ctx, id, reqEditors...)
+func (c *ClientWithResponses) FindPetByIDWithResponse(ctx context.Context, iD int64, reqEditors ...RequestEditorFn) (*FindPetByIDResponse, error) {
+	rsp, err := c.FindPetByID(ctx, iD, reqEditors...)
 	if err != nil {
 		return nil, err
 	}
@@ -590,7 +590,7 @@ func ParseFindPetsResponse(rsp *http.Response) (*FindPetsResponse, error) {
 		if err := json.Unmarshal(bodyBytes, &dest); err != nil {
 			return nil, err
 		}
-		response.JSON200 = &dest
+		response.JSON = &dest
 
 	case strings.Contains(rsp.Header.Get("Content-Type"), "json") && true:
 		var dest Error
@@ -623,7 +623,7 @@ func ParseAddPetResponse(rsp *http.Response) (*AddPetResponse, error) {
 		if err := json.Unmarshal(bodyBytes, &dest); err != nil {
 			return nil, err
 		}
-		response.JSON200 = &dest
+		response.JSON = &dest
 
 	case strings.Contains(rsp.Header.Get("Content-Type"), "json") && true:
 		var dest Error
@@ -682,7 +682,7 @@ func ParseFindPetByIDResponse(rsp *http.Response) (*FindPetByIDResponse, error) 
 		if err := json.Unmarshal(bodyBytes, &dest); err != nil {
 			return nil, err
 		}
-		response.JSON200 = &dest
+		response.JSON = &dest
 
 	case strings.Contains(rsp.Header.Get("Content-Type"), "json") && true:
 		var dest Error

--- a/go.mod
+++ b/go.mod
@@ -5,6 +5,7 @@ require (
 	github.com/getkin/kin-openapi v0.61.0
 	github.com/go-chi/chi/v5 v5.0.0
 	github.com/golangci/lint-1 v0.0.0-20181222135242-d2cdd8c08219
+	github.com/kenshaw/snaker v0.1.6
 	github.com/labstack/echo/v4 v4.2.1
 	github.com/lestrrat-go/jwx v1.2.7
 	github.com/matryer/moq v0.0.0-20190312154309-6cfb0558e1bd

--- a/go.sum
+++ b/go.sum
@@ -24,6 +24,8 @@ github.com/golangci/lint-1 v0.0.0-20181222135242-d2cdd8c08219 h1:utua3L2IbQJmauC
 github.com/golangci/lint-1 v0.0.0-20181222135242-d2cdd8c08219/go.mod h1:/X8TswGSh1pIozq4ZwCfxS0WA5JGXguxk94ar/4c87Y=
 github.com/gorilla/mux v1.8.0 h1:i40aqfkR1h2SlN9hojwV5ZA91wcXFOvkdNIeFDP5koI=
 github.com/gorilla/mux v1.8.0/go.mod h1:DVbg23sWSpFRCP0SfiEN6jmj59UnW/n46BH5rLB71So=
+github.com/kenshaw/snaker v0.1.6 h1:yJPTEMlQOQrIC5a+mPILNbDOkocqNTSIawMMroSttWg=
+github.com/kenshaw/snaker v0.1.6/go.mod h1:DNyRUqHMZ18/zioxr6R7m4kSxxf2+QmB0BXoORsXRaY=
 github.com/kr/pretty v0.1.0 h1:L/CwN0zerZDmRFUapSPitk6f+Q3+0za1rQkzVuMiMFI=
 github.com/kr/pretty v0.1.0/go.mod h1:dAy3ld7l9f0ibDNOQOHHMYYIIbhfbHSm3C4ZsoJORNo=
 github.com/kr/pty v1.1.1/go.mod h1:pFQYn66WHrOpPYNljwOMqo10TkYh1fy3cYio2l3bCsQ=

--- a/internal/test/client/client.gen.go
+++ b/internal/test/client/client.gen.go
@@ -34,14 +34,14 @@ type SchemaObject struct {
 // PostBothJSONBody defines parameters for PostBoth.
 type PostBothJSONBody SchemaObject
 
-// PostJsonJSONBody defines parameters for PostJson.
-type PostJsonJSONBody SchemaObject
+// PostJSONJSONBody defines parameters for PostJSON.
+type PostJSONJSONBody SchemaObject
 
 // PostBothJSONRequestBody defines body for PostBoth for application/json ContentType.
 type PostBothJSONRequestBody PostBothJSONBody
 
-// PostJsonJSONRequestBody defines body for PostJson for application/json ContentType.
-type PostJsonJSONRequestBody PostJsonJSONBody
+// PostJSONJSONRequestBody defines body for PostJSON for application/json ContentType.
+type PostJSONJSONRequestBody PostJSONJSONBody
 
 // RequestEditorFn  is the function signature for the RequestEditor callback function
 type RequestEditorFn func(ctx context.Context, req *http.Request) error
@@ -124,13 +124,13 @@ type ClientInterface interface {
 	// GetBoth request
 	GetBoth(ctx context.Context, reqEditors ...RequestEditorFn) (*http.Response, error)
 
-	// PostJson request with any body
-	PostJsonWithBody(ctx context.Context, contentType string, body io.Reader, reqEditors ...RequestEditorFn) (*http.Response, error)
+	// PostJSON request with any body
+	PostJSONWithBody(ctx context.Context, contentType string, body io.Reader, reqEditors ...RequestEditorFn) (*http.Response, error)
 
-	PostJson(ctx context.Context, body PostJsonJSONRequestBody, reqEditors ...RequestEditorFn) (*http.Response, error)
+	PostJSON(ctx context.Context, body PostJSONJSONRequestBody, reqEditors ...RequestEditorFn) (*http.Response, error)
 
-	// GetJson request
-	GetJson(ctx context.Context, reqEditors ...RequestEditorFn) (*http.Response, error)
+	// GetJSON request
+	GetJSON(ctx context.Context, reqEditors ...RequestEditorFn) (*http.Response, error)
 
 	// PostOther request with any body
 	PostOtherWithBody(ctx context.Context, contentType string, body io.Reader, reqEditors ...RequestEditorFn) (*http.Response, error)
@@ -138,8 +138,8 @@ type ClientInterface interface {
 	// GetOther request
 	GetOther(ctx context.Context, reqEditors ...RequestEditorFn) (*http.Response, error)
 
-	// GetJsonWithTrailingSlash request
-	GetJsonWithTrailingSlash(ctx context.Context, reqEditors ...RequestEditorFn) (*http.Response, error)
+	// GetJSONWithTrailingSlash request
+	GetJSONWithTrailingSlash(ctx context.Context, reqEditors ...RequestEditorFn) (*http.Response, error)
 }
 
 func (c *Client) PostBothWithBody(ctx context.Context, contentType string, body io.Reader, reqEditors ...RequestEditorFn) (*http.Response, error) {
@@ -178,8 +178,8 @@ func (c *Client) GetBoth(ctx context.Context, reqEditors ...RequestEditorFn) (*h
 	return c.Client.Do(req)
 }
 
-func (c *Client) PostJsonWithBody(ctx context.Context, contentType string, body io.Reader, reqEditors ...RequestEditorFn) (*http.Response, error) {
-	req, err := NewPostJsonRequestWithBody(c.Server, contentType, body)
+func (c *Client) PostJSONWithBody(ctx context.Context, contentType string, body io.Reader, reqEditors ...RequestEditorFn) (*http.Response, error) {
+	req, err := NewPostJSONRequestWithBody(c.Server, contentType, body)
 	if err != nil {
 		return nil, err
 	}
@@ -190,8 +190,8 @@ func (c *Client) PostJsonWithBody(ctx context.Context, contentType string, body 
 	return c.Client.Do(req)
 }
 
-func (c *Client) PostJson(ctx context.Context, body PostJsonJSONRequestBody, reqEditors ...RequestEditorFn) (*http.Response, error) {
-	req, err := NewPostJsonRequest(c.Server, body)
+func (c *Client) PostJSON(ctx context.Context, body PostJSONJSONRequestBody, reqEditors ...RequestEditorFn) (*http.Response, error) {
+	req, err := NewPostJSONRequest(c.Server, body)
 	if err != nil {
 		return nil, err
 	}
@@ -202,8 +202,8 @@ func (c *Client) PostJson(ctx context.Context, body PostJsonJSONRequestBody, req
 	return c.Client.Do(req)
 }
 
-func (c *Client) GetJson(ctx context.Context, reqEditors ...RequestEditorFn) (*http.Response, error) {
-	req, err := NewGetJsonRequest(c.Server)
+func (c *Client) GetJSON(ctx context.Context, reqEditors ...RequestEditorFn) (*http.Response, error) {
+	req, err := NewGetJSONRequest(c.Server)
 	if err != nil {
 		return nil, err
 	}
@@ -238,8 +238,8 @@ func (c *Client) GetOther(ctx context.Context, reqEditors ...RequestEditorFn) (*
 	return c.Client.Do(req)
 }
 
-func (c *Client) GetJsonWithTrailingSlash(ctx context.Context, reqEditors ...RequestEditorFn) (*http.Response, error) {
-	req, err := NewGetJsonWithTrailingSlashRequest(c.Server)
+func (c *Client) GetJSONWithTrailingSlash(ctx context.Context, reqEditors ...RequestEditorFn) (*http.Response, error) {
+	req, err := NewGetJSONWithTrailingSlashRequest(c.Server)
 	if err != nil {
 		return nil, err
 	}
@@ -317,19 +317,19 @@ func NewGetBothRequest(server string) (*http.Request, error) {
 	return req, nil
 }
 
-// NewPostJsonRequest calls the generic PostJson builder with application/json body
-func NewPostJsonRequest(server string, body PostJsonJSONRequestBody) (*http.Request, error) {
+// NewPostJSONRequest calls the generic PostJSON builder with application/json body
+func NewPostJSONRequest(server string, body PostJSONJSONRequestBody) (*http.Request, error) {
 	var bodyReader io.Reader
 	buf, err := json.Marshal(body)
 	if err != nil {
 		return nil, err
 	}
 	bodyReader = bytes.NewReader(buf)
-	return NewPostJsonRequestWithBody(server, "application/json", bodyReader)
+	return NewPostJSONRequestWithBody(server, "application/json", bodyReader)
 }
 
-// NewPostJsonRequestWithBody generates requests for PostJson with any type of body
-func NewPostJsonRequestWithBody(server string, contentType string, body io.Reader) (*http.Request, error) {
+// NewPostJSONRequestWithBody generates requests for PostJSON with any type of body
+func NewPostJSONRequestWithBody(server string, contentType string, body io.Reader) (*http.Request, error) {
 	var err error
 
 	serverURL, err := url.Parse(server)
@@ -357,8 +357,8 @@ func NewPostJsonRequestWithBody(server string, contentType string, body io.Reade
 	return req, nil
 }
 
-// NewGetJsonRequest generates requests for GetJson
-func NewGetJsonRequest(server string) (*http.Request, error) {
+// NewGetJSONRequest generates requests for GetJSON
+func NewGetJSONRequest(server string) (*http.Request, error) {
 	var err error
 
 	serverURL, err := url.Parse(server)
@@ -440,8 +440,8 @@ func NewGetOtherRequest(server string) (*http.Request, error) {
 	return req, nil
 }
 
-// NewGetJsonWithTrailingSlashRequest generates requests for GetJsonWithTrailingSlash
-func NewGetJsonWithTrailingSlashRequest(server string) (*http.Request, error) {
+// NewGetJSONWithTrailingSlashRequest generates requests for GetJSONWithTrailingSlash
+func NewGetJSONWithTrailingSlashRequest(server string) (*http.Request, error) {
 	var err error
 
 	serverURL, err := url.Parse(server)
@@ -518,13 +518,13 @@ type ClientWithResponsesInterface interface {
 	// GetBoth request
 	GetBothWithResponse(ctx context.Context, reqEditors ...RequestEditorFn) (*GetBothResponse, error)
 
-	// PostJson request with any body
-	PostJsonWithBodyWithResponse(ctx context.Context, contentType string, body io.Reader, reqEditors ...RequestEditorFn) (*PostJsonResponse, error)
+	// PostJSON request with any body
+	PostJSONWithBodyWithResponse(ctx context.Context, contentType string, body io.Reader, reqEditors ...RequestEditorFn) (*PostJSONResponse, error)
 
-	PostJsonWithResponse(ctx context.Context, body PostJsonJSONRequestBody, reqEditors ...RequestEditorFn) (*PostJsonResponse, error)
+	PostJSONWithResponse(ctx context.Context, body PostJSONJSONRequestBody, reqEditors ...RequestEditorFn) (*PostJSONResponse, error)
 
-	// GetJson request
-	GetJsonWithResponse(ctx context.Context, reqEditors ...RequestEditorFn) (*GetJsonResponse, error)
+	// GetJSON request
+	GetJSONWithResponse(ctx context.Context, reqEditors ...RequestEditorFn) (*GetJSONResponse, error)
 
 	// PostOther request with any body
 	PostOtherWithBodyWithResponse(ctx context.Context, contentType string, body io.Reader, reqEditors ...RequestEditorFn) (*PostOtherResponse, error)
@@ -532,8 +532,8 @@ type ClientWithResponsesInterface interface {
 	// GetOther request
 	GetOtherWithResponse(ctx context.Context, reqEditors ...RequestEditorFn) (*GetOtherResponse, error)
 
-	// GetJsonWithTrailingSlash request
-	GetJsonWithTrailingSlashWithResponse(ctx context.Context, reqEditors ...RequestEditorFn) (*GetJsonWithTrailingSlashResponse, error)
+	// GetJSONWithTrailingSlash request
+	GetJSONWithTrailingSlashWithResponse(ctx context.Context, reqEditors ...RequestEditorFn) (*GetJSONWithTrailingSlashResponse, error)
 }
 
 type PostBothResponse struct {
@@ -578,13 +578,13 @@ func (r GetBothResponse) StatusCode() int {
 	return 0
 }
 
-type PostJsonResponse struct {
+type PostJSONResponse struct {
 	Body         []byte
 	HTTPResponse *http.Response
 }
 
 // Status returns HTTPResponse.Status
-func (r PostJsonResponse) Status() string {
+func (r PostJSONResponse) Status() string {
 	if r.HTTPResponse != nil {
 		return r.HTTPResponse.Status
 	}
@@ -592,20 +592,20 @@ func (r PostJsonResponse) Status() string {
 }
 
 // StatusCode returns HTTPResponse.StatusCode
-func (r PostJsonResponse) StatusCode() int {
+func (r PostJSONResponse) StatusCode() int {
 	if r.HTTPResponse != nil {
 		return r.HTTPResponse.StatusCode
 	}
 	return 0
 }
 
-type GetJsonResponse struct {
+type GetJSONResponse struct {
 	Body         []byte
 	HTTPResponse *http.Response
 }
 
 // Status returns HTTPResponse.Status
-func (r GetJsonResponse) Status() string {
+func (r GetJSONResponse) Status() string {
 	if r.HTTPResponse != nil {
 		return r.HTTPResponse.Status
 	}
@@ -613,7 +613,7 @@ func (r GetJsonResponse) Status() string {
 }
 
 // StatusCode returns HTTPResponse.StatusCode
-func (r GetJsonResponse) StatusCode() int {
+func (r GetJSONResponse) StatusCode() int {
 	if r.HTTPResponse != nil {
 		return r.HTTPResponse.StatusCode
 	}
@@ -662,13 +662,13 @@ func (r GetOtherResponse) StatusCode() int {
 	return 0
 }
 
-type GetJsonWithTrailingSlashResponse struct {
+type GetJSONWithTrailingSlashResponse struct {
 	Body         []byte
 	HTTPResponse *http.Response
 }
 
 // Status returns HTTPResponse.Status
-func (r GetJsonWithTrailingSlashResponse) Status() string {
+func (r GetJSONWithTrailingSlashResponse) Status() string {
 	if r.HTTPResponse != nil {
 		return r.HTTPResponse.Status
 	}
@@ -676,7 +676,7 @@ func (r GetJsonWithTrailingSlashResponse) Status() string {
 }
 
 // StatusCode returns HTTPResponse.StatusCode
-func (r GetJsonWithTrailingSlashResponse) StatusCode() int {
+func (r GetJSONWithTrailingSlashResponse) StatusCode() int {
 	if r.HTTPResponse != nil {
 		return r.HTTPResponse.StatusCode
 	}
@@ -709,30 +709,30 @@ func (c *ClientWithResponses) GetBothWithResponse(ctx context.Context, reqEditor
 	return ParseGetBothResponse(rsp)
 }
 
-// PostJsonWithBodyWithResponse request with arbitrary body returning *PostJsonResponse
-func (c *ClientWithResponses) PostJsonWithBodyWithResponse(ctx context.Context, contentType string, body io.Reader, reqEditors ...RequestEditorFn) (*PostJsonResponse, error) {
-	rsp, err := c.PostJsonWithBody(ctx, contentType, body, reqEditors...)
+// PostJSONWithBodyWithResponse request with arbitrary body returning *PostJSONResponse
+func (c *ClientWithResponses) PostJSONWithBodyWithResponse(ctx context.Context, contentType string, body io.Reader, reqEditors ...RequestEditorFn) (*PostJSONResponse, error) {
+	rsp, err := c.PostJSONWithBody(ctx, contentType, body, reqEditors...)
 	if err != nil {
 		return nil, err
 	}
-	return ParsePostJsonResponse(rsp)
+	return ParsePostJSONResponse(rsp)
 }
 
-func (c *ClientWithResponses) PostJsonWithResponse(ctx context.Context, body PostJsonJSONRequestBody, reqEditors ...RequestEditorFn) (*PostJsonResponse, error) {
-	rsp, err := c.PostJson(ctx, body, reqEditors...)
+func (c *ClientWithResponses) PostJSONWithResponse(ctx context.Context, body PostJSONJSONRequestBody, reqEditors ...RequestEditorFn) (*PostJSONResponse, error) {
+	rsp, err := c.PostJSON(ctx, body, reqEditors...)
 	if err != nil {
 		return nil, err
 	}
-	return ParsePostJsonResponse(rsp)
+	return ParsePostJSONResponse(rsp)
 }
 
-// GetJsonWithResponse request returning *GetJsonResponse
-func (c *ClientWithResponses) GetJsonWithResponse(ctx context.Context, reqEditors ...RequestEditorFn) (*GetJsonResponse, error) {
-	rsp, err := c.GetJson(ctx, reqEditors...)
+// GetJSONWithResponse request returning *GetJSONResponse
+func (c *ClientWithResponses) GetJSONWithResponse(ctx context.Context, reqEditors ...RequestEditorFn) (*GetJSONResponse, error) {
+	rsp, err := c.GetJSON(ctx, reqEditors...)
 	if err != nil {
 		return nil, err
 	}
-	return ParseGetJsonResponse(rsp)
+	return ParseGetJSONResponse(rsp)
 }
 
 // PostOtherWithBodyWithResponse request with arbitrary body returning *PostOtherResponse
@@ -753,13 +753,13 @@ func (c *ClientWithResponses) GetOtherWithResponse(ctx context.Context, reqEdito
 	return ParseGetOtherResponse(rsp)
 }
 
-// GetJsonWithTrailingSlashWithResponse request returning *GetJsonWithTrailingSlashResponse
-func (c *ClientWithResponses) GetJsonWithTrailingSlashWithResponse(ctx context.Context, reqEditors ...RequestEditorFn) (*GetJsonWithTrailingSlashResponse, error) {
-	rsp, err := c.GetJsonWithTrailingSlash(ctx, reqEditors...)
+// GetJSONWithTrailingSlashWithResponse request returning *GetJSONWithTrailingSlashResponse
+func (c *ClientWithResponses) GetJSONWithTrailingSlashWithResponse(ctx context.Context, reqEditors ...RequestEditorFn) (*GetJSONWithTrailingSlashResponse, error) {
+	rsp, err := c.GetJSONWithTrailingSlash(ctx, reqEditors...)
 	if err != nil {
 		return nil, err
 	}
-	return ParseGetJsonWithTrailingSlashResponse(rsp)
+	return ParseGetJSONWithTrailingSlashResponse(rsp)
 }
 
 // ParsePostBothResponse parses an HTTP response from a PostBothWithResponse call
@@ -794,15 +794,15 @@ func ParseGetBothResponse(rsp *http.Response) (*GetBothResponse, error) {
 	return response, nil
 }
 
-// ParsePostJsonResponse parses an HTTP response from a PostJsonWithResponse call
-func ParsePostJsonResponse(rsp *http.Response) (*PostJsonResponse, error) {
+// ParsePostJSONResponse parses an HTTP response from a PostJSONWithResponse call
+func ParsePostJSONResponse(rsp *http.Response) (*PostJSONResponse, error) {
 	bodyBytes, err := ioutil.ReadAll(rsp.Body)
 	defer func() { _ = rsp.Body.Close() }()
 	if err != nil {
 		return nil, err
 	}
 
-	response := &PostJsonResponse{
+	response := &PostJSONResponse{
 		Body:         bodyBytes,
 		HTTPResponse: rsp,
 	}
@@ -810,15 +810,15 @@ func ParsePostJsonResponse(rsp *http.Response) (*PostJsonResponse, error) {
 	return response, nil
 }
 
-// ParseGetJsonResponse parses an HTTP response from a GetJsonWithResponse call
-func ParseGetJsonResponse(rsp *http.Response) (*GetJsonResponse, error) {
+// ParseGetJSONResponse parses an HTTP response from a GetJSONWithResponse call
+func ParseGetJSONResponse(rsp *http.Response) (*GetJSONResponse, error) {
 	bodyBytes, err := ioutil.ReadAll(rsp.Body)
 	defer func() { _ = rsp.Body.Close() }()
 	if err != nil {
 		return nil, err
 	}
 
-	response := &GetJsonResponse{
+	response := &GetJSONResponse{
 		Body:         bodyBytes,
 		HTTPResponse: rsp,
 	}
@@ -858,15 +858,15 @@ func ParseGetOtherResponse(rsp *http.Response) (*GetOtherResponse, error) {
 	return response, nil
 }
 
-// ParseGetJsonWithTrailingSlashResponse parses an HTTP response from a GetJsonWithTrailingSlashWithResponse call
-func ParseGetJsonWithTrailingSlashResponse(rsp *http.Response) (*GetJsonWithTrailingSlashResponse, error) {
+// ParseGetJSONWithTrailingSlashResponse parses an HTTP response from a GetJSONWithTrailingSlashWithResponse call
+func ParseGetJSONWithTrailingSlashResponse(rsp *http.Response) (*GetJSONWithTrailingSlashResponse, error) {
 	bodyBytes, err := ioutil.ReadAll(rsp.Body)
 	defer func() { _ = rsp.Body.Close() }()
 	if err != nil {
 		return nil, err
 	}
 
-	response := &GetJsonWithTrailingSlashResponse{
+	response := &GetJSONWithTrailingSlashResponse{
 		Body:         bodyBytes,
 		HTTPResponse: rsp,
 	}
@@ -884,10 +884,10 @@ type ServerInterface interface {
 	GetBoth(ctx echo.Context) error
 
 	// (POST /with_json_body)
-	PostJson(ctx echo.Context) error
+	PostJSON(ctx echo.Context) error
 
 	// (GET /with_json_response)
-	GetJson(ctx echo.Context) error
+	GetJSON(ctx echo.Context) error
 
 	// (POST /with_other_body)
 	PostOther(ctx echo.Context) error
@@ -896,7 +896,7 @@ type ServerInterface interface {
 	GetOther(ctx echo.Context) error
 
 	// (GET /with_trailing_slash/)
-	GetJsonWithTrailingSlash(ctx echo.Context) error
+	GetJSONWithTrailingSlash(ctx echo.Context) error
 }
 
 // ServerInterfaceWrapper converts echo contexts to parameters.
@@ -922,23 +922,23 @@ func (w *ServerInterfaceWrapper) GetBoth(ctx echo.Context) error {
 	return err
 }
 
-// PostJson converts echo context to params.
-func (w *ServerInterfaceWrapper) PostJson(ctx echo.Context) error {
+// PostJSON converts echo context to params.
+func (w *ServerInterfaceWrapper) PostJSON(ctx echo.Context) error {
 	var err error
 
 	// Invoke the callback with all the unmarshalled arguments
-	err = w.Handler.PostJson(ctx)
+	err = w.Handler.PostJSON(ctx)
 	return err
 }
 
-// GetJson converts echo context to params.
-func (w *ServerInterfaceWrapper) GetJson(ctx echo.Context) error {
+// GetJSON converts echo context to params.
+func (w *ServerInterfaceWrapper) GetJSON(ctx echo.Context) error {
 	var err error
 
 	ctx.Set(OpenIdScopes, []string{"json.read", "json.admin"})
 
 	// Invoke the callback with all the unmarshalled arguments
-	err = w.Handler.GetJson(ctx)
+	err = w.Handler.GetJSON(ctx)
 	return err
 }
 
@@ -960,14 +960,14 @@ func (w *ServerInterfaceWrapper) GetOther(ctx echo.Context) error {
 	return err
 }
 
-// GetJsonWithTrailingSlash converts echo context to params.
-func (w *ServerInterfaceWrapper) GetJsonWithTrailingSlash(ctx echo.Context) error {
+// GetJSONWithTrailingSlash converts echo context to params.
+func (w *ServerInterfaceWrapper) GetJSONWithTrailingSlash(ctx echo.Context) error {
 	var err error
 
 	ctx.Set(OpenIdScopes, []string{"json.read", "json.admin"})
 
 	// Invoke the callback with all the unmarshalled arguments
-	err = w.Handler.GetJsonWithTrailingSlash(ctx)
+	err = w.Handler.GetJSONWithTrailingSlash(ctx)
 	return err
 }
 
@@ -1001,26 +1001,26 @@ func RegisterHandlersWithBaseURL(router EchoRouter, si ServerInterface, baseURL 
 
 	router.POST(baseURL+"/with_both_bodies", wrapper.PostBoth)
 	router.GET(baseURL+"/with_both_responses", wrapper.GetBoth)
-	router.POST(baseURL+"/with_json_body", wrapper.PostJson)
-	router.GET(baseURL+"/with_json_response", wrapper.GetJson)
+	router.POST(baseURL+"/with_json_body", wrapper.PostJSON)
+	router.GET(baseURL+"/with_json_response", wrapper.GetJSON)
 	router.POST(baseURL+"/with_other_body", wrapper.PostOther)
 	router.GET(baseURL+"/with_other_response", wrapper.GetOther)
-	router.GET(baseURL+"/with_trailing_slash/", wrapper.GetJsonWithTrailingSlash)
+	router.GET(baseURL+"/with_trailing_slash/", wrapper.GetJSONWithTrailingSlash)
 
 }
 
 // Base64 encoded, gzipped, json marshaled Swagger object
 var swaggerSpec = []string{
 
-	"H4sIAAAAAAAC/8yUz24TMRDGX2U1cFyyKdz2CAdUJAgikTiEqHK8k9jVrm1mJq1W0b47GicliahCkGjV",
-	"SzTO/NE338/rLdjYpRgwCEO9BbYOO5PDaQ4ny1u0oudEMSGJx5xdeWL5YjrUg/QJoQYW8mENQwkU28cS",
-	"msGfG0/YQD3fVZVHoxaDlviwitrcIFvySXwMUMPMeS4EWbi4dygOqRCHxYfWY5DChGYffvfiviGnGBi5",
-	"MITFGgOSEWwKG4nQStv/CFBC6y0GzjpDXgQ+X89UvXhR+TBDlmKKdIcEJdwh8U7K1Wg8GmthTBhM8lDD",
-	"u9F4dAUlJCMu+1Pde3E3y5h/mr1pKXK2Uo00utd1AzV8jSzvozjYuYN6anqtszEIhtxiUmq9zU3VLauM",
-	"B1gavSZcQQ2vqgPNao+yOuGo/h6PilZQ3rAQmu505CpSZwRqWPpgqIfyD5gnNIU2mP/YOw912LSt1hw5",
-	"cZTdwhof8eIjHqw4qn07Hr9UE4bDjipJaffnWX9S5c/C+p8IZfUP2XOAfut/QkAqi9FuyEsP9XwLk4RZ",
-	"wBx07ojQNFDuYtN0PsBiWBx2ifo+XIBionUXs3i2j2Un/xIWhwXOw/hfV1zI+NaH9Q23hl31t2uij/Fs",
-	"3zLVjhd6b4bhVwAAAP//2pHiCAkHAAA=",
+	"H4sIAAAAAAAC/8yUz24TMRDGX2U1cFyyKdz2CAdUJBpEInEIUeV4J7GrXdvMTFqton13NE5KElGFIEHV",
+	"SzTO/NE338/rLdjYpRgwCEO9BbYOO5PDaQ4nyzu0oudEMSGJx5xdeWK5MR3qQfqEUAML+bCGoQSK7VMJ",
+	"zeCPjSdsoJ7vqsqjUYtBS3xYRW1ukC35JD4GqGHmPBeCLFw8OBSHVIjD4kPrMUhhQrMPv3lxX5FTDIxc",
+	"GMJijQHJCDaFjURope2/Byih9RYDZ50hLwKfr2eqXryofJghSzFFukeCEu6ReCflajQejbUwJgwmeajh",
+	"3Wg8uoISkhGX/akevLjbZcw/zd60FDlbqUYa3eu6gRq+RJb3URzs3EE9Nb3W2RgEQ24xKbXe5qbqjlXG",
+	"IyyNXhOuoIZX1YFmtUdZnXBUf49HRSsob1gITXc6chWpMwI1LH0w1EP5G8wTmkIbzH/snYc6bNpWa46c",
+	"OMpuYY1PePERD1Yc1b4dj1+qCcNhR5WktPvzrD9NJzfPw/qvCGX1j9lzgH7p/4+AVBaj3ZCXHur5FiYJ",
+	"s4A56NwRoWmg3MWm6XyAxbA47BL1fbgAxUTrLmbxbB/LTv4lLA4LnIfxr664kPGtD+tbbg276k/XRB/j",
+	"2b5lqh0v9N4Mw88AAAD//1BYVOcJBwAA",
 }
 
 // GetSwagger returns the content of the embedded swagger specification file

--- a/internal/test/components/components.gen.go
+++ b/internal/test/components/components.gen.go
@@ -24,7 +24,7 @@ import (
 
 // Has additional properties of type int
 type AdditionalPropertiesObject1 struct {
-	Id                   int            `json:"id"`
+	ID                   int            `json:"id"`
 	Name                 string         `json:"name"`
 	Optional             *string        `json:"optional,omitempty"`
 	AdditionalProperties map[string]int `json:"-"`
@@ -32,7 +32,7 @@ type AdditionalPropertiesObject1 struct {
 
 // Does not allow additional properties
 type AdditionalPropertiesObject2 struct {
-	Id   int    `json:"id"`
+	ID   int    `json:"id"`
 	Name string `json:"name"`
 }
 
@@ -60,8 +60,8 @@ type AdditionalPropertiesObject5 struct {
 	AdditionalProperties map[string]SchemaObject `json:"-"`
 }
 
-// ObjectWithJsonField defines model for ObjectWithJsonField.
-type ObjectWithJsonField struct {
+// ObjectWithJSONField defines model for ObjectWithJsonField.
+type ObjectWithJSONField struct {
 	Name   string          `json:"name"`
 	Value1 json.RawMessage `json:"value1"`
 	Value2 json.RawMessage `json:"value2,omitempty"`
@@ -387,7 +387,7 @@ func (a *AdditionalPropertiesObject1) UnmarshalJSON(b []byte) error {
 	}
 
 	if raw, found := object["id"]; found {
-		err = json.Unmarshal(raw, &a.Id)
+		err = json.Unmarshal(raw, &a.ID)
 		if err != nil {
 			return fmt.Errorf("error reading 'id': %w", err)
 		}
@@ -429,7 +429,7 @@ func (a AdditionalPropertiesObject1) MarshalJSON() ([]byte, error) {
 	var err error
 	object := make(map[string]json.RawMessage)
 
-	object["id"], err = json.Marshal(a.Id)
+	object["id"], err = json.Marshal(a.ID)
 	if err != nil {
 		return nil, fmt.Errorf("error marshaling 'id': %w", err)
 	}
@@ -1061,13 +1061,13 @@ type ClientWithResponsesInterface interface {
 type EnsureEverythingIsReferencedResponse struct {
 	Body         []byte
 	HTTPResponse *http.Response
-	JSON200      *struct {
+	JSON         *struct {
 		// Has additional properties with schema for dictionaries
 		Five *AdditionalPropertiesObject5 `json:"five,omitempty"`
 
 		// Has anonymous field which has additional properties
 		Four      *AdditionalPropertiesObject4 `json:"four,omitempty"`
-		JsonField *ObjectWithJsonField         `json:"jsonField,omitempty"`
+		JSONField *ObjectWithJSONField         `json:"jsonField,omitempty"`
 
 		// Has additional properties of type int
 		One *AdditionalPropertiesObject1 `json:"one,omitempty"`
@@ -1205,7 +1205,7 @@ func ParseEnsureEverythingIsReferencedResponse(rsp *http.Response) (*EnsureEvery
 
 			// Has anonymous field which has additional properties
 			Four      *AdditionalPropertiesObject4 `json:"four,omitempty"`
-			JsonField *ObjectWithJsonField         `json:"jsonField,omitempty"`
+			JSONField *ObjectWithJSONField         `json:"jsonField,omitempty"`
 
 			// Has additional properties of type int
 			One *AdditionalPropertiesObject1 `json:"one,omitempty"`
@@ -1219,7 +1219,7 @@ func ParseEnsureEverythingIsReferencedResponse(rsp *http.Response) (*EnsureEvery
 		if err := json.Unmarshal(bodyBytes, &dest); err != nil {
 			return nil, err
 		}
-		response.JSON200 = &dest
+		response.JSON = &dest
 
 	case strings.Contains(rsp.Header.Get("Content-Type"), "json") && true:
 		var dest struct {

--- a/internal/test/issues/issue-312/issue.gen.go
+++ b/internal/test/issues/issue-312/issue.gen.go
@@ -123,7 +123,7 @@ func WithRequestEditorFn(fn RequestEditorFn) ClientOption {
 // The interface specification for the client above.
 type ClientInterface interface {
 	// GetPet request
-	GetPet(ctx context.Context, petId string, reqEditors ...RequestEditorFn) (*http.Response, error)
+	GetPet(ctx context.Context, petID string, reqEditors ...RequestEditorFn) (*http.Response, error)
 
 	// ValidatePets request with any body
 	ValidatePetsWithBody(ctx context.Context, contentType string, body io.Reader, reqEditors ...RequestEditorFn) (*http.Response, error)
@@ -131,8 +131,8 @@ type ClientInterface interface {
 	ValidatePets(ctx context.Context, body ValidatePetsJSONRequestBody, reqEditors ...RequestEditorFn) (*http.Response, error)
 }
 
-func (c *Client) GetPet(ctx context.Context, petId string, reqEditors ...RequestEditorFn) (*http.Response, error) {
-	req, err := NewGetPetRequest(c.Server, petId)
+func (c *Client) GetPet(ctx context.Context, petID string, reqEditors ...RequestEditorFn) (*http.Response, error) {
+	req, err := NewGetPetRequest(c.Server, petID)
 	if err != nil {
 		return nil, err
 	}
@@ -168,12 +168,12 @@ func (c *Client) ValidatePets(ctx context.Context, body ValidatePetsJSONRequestB
 }
 
 // NewGetPetRequest generates requests for GetPet
-func NewGetPetRequest(server string, petId string) (*http.Request, error) {
+func NewGetPetRequest(server string, petID string) (*http.Request, error) {
 	var err error
 
 	var pathParam0 string
 
-	pathParam0, err = runtime.StyleParamWithLocation("simple", false, "petId", runtime.ParamLocationPath, petId)
+	pathParam0, err = runtime.StyleParamWithLocation("simple", false, "petId", runtime.ParamLocationPath, petID)
 	if err != nil {
 		return nil, err
 	}
@@ -285,7 +285,7 @@ func WithBaseURL(baseURL string) ClientOption {
 // ClientWithResponsesInterface is the interface specification for the client with responses above.
 type ClientWithResponsesInterface interface {
 	// GetPet request
-	GetPetWithResponse(ctx context.Context, petId string, reqEditors ...RequestEditorFn) (*GetPetResponse, error)
+	GetPetWithResponse(ctx context.Context, petID string, reqEditors ...RequestEditorFn) (*GetPetResponse, error)
 
 	// ValidatePets request with any body
 	ValidatePetsWithBodyWithResponse(ctx context.Context, contentType string, body io.Reader, reqEditors ...RequestEditorFn) (*ValidatePetsResponse, error)
@@ -296,7 +296,7 @@ type ClientWithResponsesInterface interface {
 type GetPetResponse struct {
 	Body         []byte
 	HTTPResponse *http.Response
-	JSON200      *Pet
+	JSON         *Pet
 }
 
 // Status returns HTTPResponse.Status
@@ -318,7 +318,7 @@ func (r GetPetResponse) StatusCode() int {
 type ValidatePetsResponse struct {
 	Body         []byte
 	HTTPResponse *http.Response
-	JSON200      *[]Pet
+	JSON         *[]Pet
 	JSONDefault  *Error
 }
 
@@ -339,8 +339,8 @@ func (r ValidatePetsResponse) StatusCode() int {
 }
 
 // GetPetWithResponse request returning *GetPetResponse
-func (c *ClientWithResponses) GetPetWithResponse(ctx context.Context, petId string, reqEditors ...RequestEditorFn) (*GetPetResponse, error) {
-	rsp, err := c.GetPet(ctx, petId, reqEditors...)
+func (c *ClientWithResponses) GetPetWithResponse(ctx context.Context, petID string, reqEditors ...RequestEditorFn) (*GetPetResponse, error) {
+	rsp, err := c.GetPet(ctx, petID, reqEditors...)
 	if err != nil {
 		return nil, err
 	}
@@ -383,7 +383,7 @@ func ParseGetPetResponse(rsp *http.Response) (*GetPetResponse, error) {
 		if err := json.Unmarshal(bodyBytes, &dest); err != nil {
 			return nil, err
 		}
-		response.JSON200 = &dest
+		response.JSON = &dest
 
 	}
 
@@ -409,7 +409,7 @@ func ParseValidatePetsResponse(rsp *http.Response) (*ValidatePetsResponse, error
 		if err := json.Unmarshal(bodyBytes, &dest); err != nil {
 			return nil, err
 		}
-		response.JSON200 = &dest
+		response.JSON = &dest
 
 	case strings.Contains(rsp.Header.Get("Content-Type"), "json") && true:
 		var dest Error
@@ -427,7 +427,7 @@ func ParseValidatePetsResponse(rsp *http.Response) (*ValidatePetsResponse, error
 type ServerInterface interface {
 	// Get pet given identifier.
 	// (GET /pets/{petId})
-	GetPet(ctx echo.Context, petId string) error
+	GetPet(ctx echo.Context, petID string) error
 	// Validate pets
 	// (POST /pets:validate)
 	ValidatePets(ctx echo.Context) error
@@ -442,15 +442,15 @@ type ServerInterfaceWrapper struct {
 func (w *ServerInterfaceWrapper) GetPet(ctx echo.Context) error {
 	var err error
 	// ------------- Path parameter "petId" -------------
-	var petId string
+	var petID string
 
-	err = runtime.BindStyledParameterWithLocation("simple", false, "petId", runtime.ParamLocationPath, ctx.Param("petId"), &petId)
+	err = runtime.BindStyledParameterWithLocation("simple", false, "petId", runtime.ParamLocationPath, ctx.Param("petId"), &petID)
 	if err != nil {
 		return echo.NewHTTPError(http.StatusBadRequest, fmt.Sprintf("Invalid format for parameter petId: %s", err))
 	}
 
 	// Invoke the callback with all the unmarshalled arguments
-	err = w.Handler.GetPet(ctx, petId)
+	err = w.Handler.GetPet(ctx, petID)
 	return err
 }
 

--- a/internal/test/issues/issue-52/issue.gen.go
+++ b/internal/test/issues/issue-52/issue.gen.go
@@ -258,7 +258,7 @@ type ClientWithResponsesInterface interface {
 type ExampleGetResponse struct {
 	Body         []byte
 	HTTPResponse *http.Response
-	JSON200      *Document
+	JSON         *Document
 }
 
 // Status returns HTTPResponse.Status
@@ -305,7 +305,7 @@ func ParseExampleGetResponse(rsp *http.Response) (*ExampleGetResponse, error) {
 		if err := json.Unmarshal(bodyBytes, &dest); err != nil {
 			return nil, err
 		}
-		response.JSON200 = &dest
+		response.JSON = &dest
 
 	}
 

--- a/internal/test/issues/issue-grab_import_names/issue.gen.go
+++ b/internal/test/issues/issue-grab_import_names/issue.gen.go
@@ -218,7 +218,7 @@ type ClientWithResponsesInterface interface {
 type GetFooResponse struct {
 	Body         []byte
 	HTTPResponse *http.Response
-	JSON200      *string
+	JSON         *string
 }
 
 // Status returns HTTPResponse.Status
@@ -265,7 +265,7 @@ func ParseGetFooResponse(rsp *http.Response) (*GetFooResponse, error) {
 		if err := json.Unmarshal(bodyBytes, &dest); err != nil {
 			return nil, err
 		}
-		response.JSON200 = &dest
+		response.JSON = &dest
 
 	}
 

--- a/internal/test/issues/issue-illegal_enum_names/issue.gen.go
+++ b/internal/test/issues/issue-illegal_enum_names/issue.gen.go
@@ -22,23 +22,23 @@ import (
 
 // Defines values for Bar.
 const (
+	Bar Bar = "1"
+
 	BarBar Bar = "Bar"
 
 	BarFoo Bar = "Foo"
 
-	BarFoo1 Bar = " Foo"
+	BarFoo1 Bar = "1Foo"
 
-	BarFoo2 Bar = " Foo "
+	BarFoo2 Bar = " Foo"
 
-	BarFoo3 Bar = "_Foo_"
+	BarFoo3 Bar = " Foo "
+
+	BarFoo4 Bar = "_Foo_"
 
 	BarFooBar Bar = "Foo Bar"
 
 	BarFooBar1 Bar = "Foo-Bar"
-
-	BarN1 Bar = "1"
-
-	BarN1Foo Bar = "1Foo"
 )
 
 // Bar defines model for Bar.
@@ -210,7 +210,7 @@ type ClientWithResponsesInterface interface {
 type GetFooResponse struct {
 	Body         []byte
 	HTTPResponse *http.Response
-	JSON200      *[]Bar
+	JSON         *[]Bar
 }
 
 // Status returns HTTPResponse.Status
@@ -257,7 +257,7 @@ func ParseGetFooResponse(rsp *http.Response) (*GetFooResponse, error) {
 		if err := json.Unmarshal(bodyBytes, &dest); err != nil {
 			return nil, err
 		}
-		response.JSON200 = &dest
+		response.JSON = &dest
 
 	}
 

--- a/internal/test/parameters/parameters.gen.go
+++ b/internal/test/parameters/parameters.gen.go
@@ -23,7 +23,7 @@ import (
 
 // ComplexObject defines model for ComplexObject.
 type ComplexObject struct {
-	Id      int    `json:"Id"`
+	ID      int    `json:"Id"`
 	IsAdmin bool   `json:"IsAdmin"`
 	Object  Object `json:"Object"`
 }
@@ -58,7 +58,7 @@ type GetCookieParams struct {
 	Co *ComplexObject `json:"co,omitempty"`
 
 	// name starting with number
-	N1s *string `json:"1s,omitempty"`
+	S *string `json:"1s,omitempty"`
 }
 
 // GetHeaderParams defines parameters for GetHeader.
@@ -85,7 +85,7 @@ type GetHeaderParams struct {
 	XComplexObject *ComplexObject `json:"X-Complex-Object,omitempty"`
 
 	// name starting with number
-	N1StartingWithNumber *string `json:"1-Starting-With-Number,omitempty"`
+	StartingWithNumber *string `json:"1-Starting-With-Number,omitempty"`
 }
 
 // GetDeepObjectParams defines parameters for GetDeepObject.
@@ -121,7 +121,7 @@ type GetQueryFormParams struct {
 	Co *ComplexObject `json:"co,omitempty"`
 
 	// name starting with number
-	N1s *string `json:"1s,omitempty"`
+	S *string `json:"1s,omitempty"`
 }
 
 // RequestEditorFn  is the function signature for the RequestEditor callback function
@@ -219,16 +219,16 @@ type ClientInterface interface {
 	GetLabelNoExplodeObject(ctx context.Context, param Object, reqEditors ...RequestEditorFn) (*http.Response, error)
 
 	// GetMatrixExplodeArray request
-	GetMatrixExplodeArray(ctx context.Context, id []int32, reqEditors ...RequestEditorFn) (*http.Response, error)
+	GetMatrixExplodeArray(ctx context.Context, iD []int32, reqEditors ...RequestEditorFn) (*http.Response, error)
 
 	// GetMatrixExplodeObject request
-	GetMatrixExplodeObject(ctx context.Context, id Object, reqEditors ...RequestEditorFn) (*http.Response, error)
+	GetMatrixExplodeObject(ctx context.Context, iD Object, reqEditors ...RequestEditorFn) (*http.Response, error)
 
 	// GetMatrixNoExplodeArray request
-	GetMatrixNoExplodeArray(ctx context.Context, id []int32, reqEditors ...RequestEditorFn) (*http.Response, error)
+	GetMatrixNoExplodeArray(ctx context.Context, iD []int32, reqEditors ...RequestEditorFn) (*http.Response, error)
 
 	// GetMatrixNoExplodeObject request
-	GetMatrixNoExplodeObject(ctx context.Context, id Object, reqEditors ...RequestEditorFn) (*http.Response, error)
+	GetMatrixNoExplodeObject(ctx context.Context, iD Object, reqEditors ...RequestEditorFn) (*http.Response, error)
 
 	// GetPassThrough request
 	GetPassThrough(ctx context.Context, param string, reqEditors ...RequestEditorFn) (*http.Response, error)
@@ -255,7 +255,7 @@ type ClientInterface interface {
 	GetSimplePrimitive(ctx context.Context, param int32, reqEditors ...RequestEditorFn) (*http.Response, error)
 
 	// GetStartingWithNumber request
-	GetStartingWithNumber(ctx context.Context, n1param string, reqEditors ...RequestEditorFn) (*http.Response, error)
+	GetStartingWithNumber(ctx context.Context, param string, reqEditors ...RequestEditorFn) (*http.Response, error)
 }
 
 func (c *Client) GetContentObject(ctx context.Context, param ComplexObject, reqEditors ...RequestEditorFn) (*http.Response, error) {
@@ -342,8 +342,8 @@ func (c *Client) GetLabelNoExplodeObject(ctx context.Context, param Object, reqE
 	return c.Client.Do(req)
 }
 
-func (c *Client) GetMatrixExplodeArray(ctx context.Context, id []int32, reqEditors ...RequestEditorFn) (*http.Response, error) {
-	req, err := NewGetMatrixExplodeArrayRequest(c.Server, id)
+func (c *Client) GetMatrixExplodeArray(ctx context.Context, iD []int32, reqEditors ...RequestEditorFn) (*http.Response, error) {
+	req, err := NewGetMatrixExplodeArrayRequest(c.Server, iD)
 	if err != nil {
 		return nil, err
 	}
@@ -354,8 +354,8 @@ func (c *Client) GetMatrixExplodeArray(ctx context.Context, id []int32, reqEdito
 	return c.Client.Do(req)
 }
 
-func (c *Client) GetMatrixExplodeObject(ctx context.Context, id Object, reqEditors ...RequestEditorFn) (*http.Response, error) {
-	req, err := NewGetMatrixExplodeObjectRequest(c.Server, id)
+func (c *Client) GetMatrixExplodeObject(ctx context.Context, iD Object, reqEditors ...RequestEditorFn) (*http.Response, error) {
+	req, err := NewGetMatrixExplodeObjectRequest(c.Server, iD)
 	if err != nil {
 		return nil, err
 	}
@@ -366,8 +366,8 @@ func (c *Client) GetMatrixExplodeObject(ctx context.Context, id Object, reqEdito
 	return c.Client.Do(req)
 }
 
-func (c *Client) GetMatrixNoExplodeArray(ctx context.Context, id []int32, reqEditors ...RequestEditorFn) (*http.Response, error) {
-	req, err := NewGetMatrixNoExplodeArrayRequest(c.Server, id)
+func (c *Client) GetMatrixNoExplodeArray(ctx context.Context, iD []int32, reqEditors ...RequestEditorFn) (*http.Response, error) {
+	req, err := NewGetMatrixNoExplodeArrayRequest(c.Server, iD)
 	if err != nil {
 		return nil, err
 	}
@@ -378,8 +378,8 @@ func (c *Client) GetMatrixNoExplodeArray(ctx context.Context, id []int32, reqEdi
 	return c.Client.Do(req)
 }
 
-func (c *Client) GetMatrixNoExplodeObject(ctx context.Context, id Object, reqEditors ...RequestEditorFn) (*http.Response, error) {
-	req, err := NewGetMatrixNoExplodeObjectRequest(c.Server, id)
+func (c *Client) GetMatrixNoExplodeObject(ctx context.Context, iD Object, reqEditors ...RequestEditorFn) (*http.Response, error) {
+	req, err := NewGetMatrixNoExplodeObjectRequest(c.Server, iD)
 	if err != nil {
 		return nil, err
 	}
@@ -486,8 +486,8 @@ func (c *Client) GetSimplePrimitive(ctx context.Context, param int32, reqEditors
 	return c.Client.Do(req)
 }
 
-func (c *Client) GetStartingWithNumber(ctx context.Context, n1param string, reqEditors ...RequestEditorFn) (*http.Response, error) {
-	req, err := NewGetStartingWithNumberRequest(c.Server, n1param)
+func (c *Client) GetStartingWithNumber(ctx context.Context, param string, reqEditors ...RequestEditorFn) (*http.Response, error) {
+	req, err := NewGetStartingWithNumberRequest(c.Server, param)
 	if err != nil {
 		return nil, err
 	}
@@ -665,10 +665,10 @@ func NewGetCookieRequest(server string, params *GetCookieParams) (*http.Request,
 		req.AddCookie(cookie6)
 	}
 
-	if params.N1s != nil {
+	if params.S != nil {
 		var cookieParam7 string
 
-		cookieParam7, err = runtime.StyleParamWithLocation("simple", true, "1s", runtime.ParamLocationCookie, *params.N1s)
+		cookieParam7, err = runtime.StyleParamWithLocation("simple", true, "1s", runtime.ParamLocationCookie, *params.S)
 		if err != nil {
 			return nil, err
 		}
@@ -786,10 +786,10 @@ func NewGetHeaderRequest(server string, params *GetHeaderParams) (*http.Request,
 		req.Header.Set("X-Complex-Object", headerParam6)
 	}
 
-	if params.N1StartingWithNumber != nil {
+	if params.StartingWithNumber != nil {
 		var headerParam7 string
 
-		headerParam7, err = runtime.StyleParamWithLocation("simple", false, "1-Starting-With-Number", runtime.ParamLocationHeader, *params.N1StartingWithNumber)
+		headerParam7, err = runtime.StyleParamWithLocation("simple", false, "1-Starting-With-Number", runtime.ParamLocationHeader, *params.StartingWithNumber)
 		if err != nil {
 			return nil, err
 		}
@@ -937,12 +937,12 @@ func NewGetLabelNoExplodeObjectRequest(server string, param Object) (*http.Reque
 }
 
 // NewGetMatrixExplodeArrayRequest generates requests for GetMatrixExplodeArray
-func NewGetMatrixExplodeArrayRequest(server string, id []int32) (*http.Request, error) {
+func NewGetMatrixExplodeArrayRequest(server string, iD []int32) (*http.Request, error) {
 	var err error
 
 	var pathParam0 string
 
-	pathParam0, err = runtime.StyleParamWithLocation("matrix", true, "id", runtime.ParamLocationPath, id)
+	pathParam0, err = runtime.StyleParamWithLocation("matrix", true, "id", runtime.ParamLocationPath, iD)
 	if err != nil {
 		return nil, err
 	}
@@ -971,12 +971,12 @@ func NewGetMatrixExplodeArrayRequest(server string, id []int32) (*http.Request, 
 }
 
 // NewGetMatrixExplodeObjectRequest generates requests for GetMatrixExplodeObject
-func NewGetMatrixExplodeObjectRequest(server string, id Object) (*http.Request, error) {
+func NewGetMatrixExplodeObjectRequest(server string, iD Object) (*http.Request, error) {
 	var err error
 
 	var pathParam0 string
 
-	pathParam0, err = runtime.StyleParamWithLocation("matrix", true, "id", runtime.ParamLocationPath, id)
+	pathParam0, err = runtime.StyleParamWithLocation("matrix", true, "id", runtime.ParamLocationPath, iD)
 	if err != nil {
 		return nil, err
 	}
@@ -1005,12 +1005,12 @@ func NewGetMatrixExplodeObjectRequest(server string, id Object) (*http.Request, 
 }
 
 // NewGetMatrixNoExplodeArrayRequest generates requests for GetMatrixNoExplodeArray
-func NewGetMatrixNoExplodeArrayRequest(server string, id []int32) (*http.Request, error) {
+func NewGetMatrixNoExplodeArrayRequest(server string, iD []int32) (*http.Request, error) {
 	var err error
 
 	var pathParam0 string
 
-	pathParam0, err = runtime.StyleParamWithLocation("matrix", false, "id", runtime.ParamLocationPath, id)
+	pathParam0, err = runtime.StyleParamWithLocation("matrix", false, "id", runtime.ParamLocationPath, iD)
 	if err != nil {
 		return nil, err
 	}
@@ -1039,12 +1039,12 @@ func NewGetMatrixNoExplodeArrayRequest(server string, id []int32) (*http.Request
 }
 
 // NewGetMatrixNoExplodeObjectRequest generates requests for GetMatrixNoExplodeObject
-func NewGetMatrixNoExplodeObjectRequest(server string, id Object) (*http.Request, error) {
+func NewGetMatrixNoExplodeObjectRequest(server string, iD Object) (*http.Request, error) {
 	var err error
 
 	var pathParam0 string
 
-	pathParam0, err = runtime.StyleParamWithLocation("matrix", false, "id", runtime.ParamLocationPath, id)
+	pathParam0, err = runtime.StyleParamWithLocation("matrix", false, "id", runtime.ParamLocationPath, iD)
 	if err != nil {
 		return nil, err
 	}
@@ -1289,9 +1289,9 @@ func NewGetQueryFormRequest(server string, params *GetQueryFormParams) (*http.Re
 
 	}
 
-	if params.N1s != nil {
+	if params.S != nil {
 
-		if queryFrag, err := runtime.StyleParamWithLocation("form", true, "1s", runtime.ParamLocationQuery, *params.N1s); err != nil {
+		if queryFrag, err := runtime.StyleParamWithLocation("form", true, "1s", runtime.ParamLocationQuery, *params.S); err != nil {
 			return nil, err
 		} else if parsed, err := url.ParseQuery(queryFrag); err != nil {
 			return nil, err
@@ -1486,12 +1486,12 @@ func NewGetSimplePrimitiveRequest(server string, param int32) (*http.Request, er
 }
 
 // NewGetStartingWithNumberRequest generates requests for GetStartingWithNumber
-func NewGetStartingWithNumberRequest(server string, n1param string) (*http.Request, error) {
+func NewGetStartingWithNumberRequest(server string, param string) (*http.Request, error) {
 	var err error
 
 	var pathParam0 string
 
-	pathParam0 = n1param
+	pathParam0 = param
 
 	serverURL, err := url.Parse(server)
 	if err != nil {
@@ -1581,16 +1581,16 @@ type ClientWithResponsesInterface interface {
 	GetLabelNoExplodeObjectWithResponse(ctx context.Context, param Object, reqEditors ...RequestEditorFn) (*GetLabelNoExplodeObjectResponse, error)
 
 	// GetMatrixExplodeArray request
-	GetMatrixExplodeArrayWithResponse(ctx context.Context, id []int32, reqEditors ...RequestEditorFn) (*GetMatrixExplodeArrayResponse, error)
+	GetMatrixExplodeArrayWithResponse(ctx context.Context, iD []int32, reqEditors ...RequestEditorFn) (*GetMatrixExplodeArrayResponse, error)
 
 	// GetMatrixExplodeObject request
-	GetMatrixExplodeObjectWithResponse(ctx context.Context, id Object, reqEditors ...RequestEditorFn) (*GetMatrixExplodeObjectResponse, error)
+	GetMatrixExplodeObjectWithResponse(ctx context.Context, iD Object, reqEditors ...RequestEditorFn) (*GetMatrixExplodeObjectResponse, error)
 
 	// GetMatrixNoExplodeArray request
-	GetMatrixNoExplodeArrayWithResponse(ctx context.Context, id []int32, reqEditors ...RequestEditorFn) (*GetMatrixNoExplodeArrayResponse, error)
+	GetMatrixNoExplodeArrayWithResponse(ctx context.Context, iD []int32, reqEditors ...RequestEditorFn) (*GetMatrixNoExplodeArrayResponse, error)
 
 	// GetMatrixNoExplodeObject request
-	GetMatrixNoExplodeObjectWithResponse(ctx context.Context, id Object, reqEditors ...RequestEditorFn) (*GetMatrixNoExplodeObjectResponse, error)
+	GetMatrixNoExplodeObjectWithResponse(ctx context.Context, iD Object, reqEditors ...RequestEditorFn) (*GetMatrixNoExplodeObjectResponse, error)
 
 	// GetPassThrough request
 	GetPassThroughWithResponse(ctx context.Context, param string, reqEditors ...RequestEditorFn) (*GetPassThroughResponse, error)
@@ -1617,7 +1617,7 @@ type ClientWithResponsesInterface interface {
 	GetSimplePrimitiveWithResponse(ctx context.Context, param int32, reqEditors ...RequestEditorFn) (*GetSimplePrimitiveResponse, error)
 
 	// GetStartingWithNumber request
-	GetStartingWithNumberWithResponse(ctx context.Context, n1param string, reqEditors ...RequestEditorFn) (*GetStartingWithNumberResponse, error)
+	GetStartingWithNumberWithResponse(ctx context.Context, param string, reqEditors ...RequestEditorFn) (*GetStartingWithNumberResponse, error)
 }
 
 type GetContentObjectResponse struct {
@@ -2104,8 +2104,8 @@ func (c *ClientWithResponses) GetLabelNoExplodeObjectWithResponse(ctx context.Co
 }
 
 // GetMatrixExplodeArrayWithResponse request returning *GetMatrixExplodeArrayResponse
-func (c *ClientWithResponses) GetMatrixExplodeArrayWithResponse(ctx context.Context, id []int32, reqEditors ...RequestEditorFn) (*GetMatrixExplodeArrayResponse, error) {
-	rsp, err := c.GetMatrixExplodeArray(ctx, id, reqEditors...)
+func (c *ClientWithResponses) GetMatrixExplodeArrayWithResponse(ctx context.Context, iD []int32, reqEditors ...RequestEditorFn) (*GetMatrixExplodeArrayResponse, error) {
+	rsp, err := c.GetMatrixExplodeArray(ctx, iD, reqEditors...)
 	if err != nil {
 		return nil, err
 	}
@@ -2113,8 +2113,8 @@ func (c *ClientWithResponses) GetMatrixExplodeArrayWithResponse(ctx context.Cont
 }
 
 // GetMatrixExplodeObjectWithResponse request returning *GetMatrixExplodeObjectResponse
-func (c *ClientWithResponses) GetMatrixExplodeObjectWithResponse(ctx context.Context, id Object, reqEditors ...RequestEditorFn) (*GetMatrixExplodeObjectResponse, error) {
-	rsp, err := c.GetMatrixExplodeObject(ctx, id, reqEditors...)
+func (c *ClientWithResponses) GetMatrixExplodeObjectWithResponse(ctx context.Context, iD Object, reqEditors ...RequestEditorFn) (*GetMatrixExplodeObjectResponse, error) {
+	rsp, err := c.GetMatrixExplodeObject(ctx, iD, reqEditors...)
 	if err != nil {
 		return nil, err
 	}
@@ -2122,8 +2122,8 @@ func (c *ClientWithResponses) GetMatrixExplodeObjectWithResponse(ctx context.Con
 }
 
 // GetMatrixNoExplodeArrayWithResponse request returning *GetMatrixNoExplodeArrayResponse
-func (c *ClientWithResponses) GetMatrixNoExplodeArrayWithResponse(ctx context.Context, id []int32, reqEditors ...RequestEditorFn) (*GetMatrixNoExplodeArrayResponse, error) {
-	rsp, err := c.GetMatrixNoExplodeArray(ctx, id, reqEditors...)
+func (c *ClientWithResponses) GetMatrixNoExplodeArrayWithResponse(ctx context.Context, iD []int32, reqEditors ...RequestEditorFn) (*GetMatrixNoExplodeArrayResponse, error) {
+	rsp, err := c.GetMatrixNoExplodeArray(ctx, iD, reqEditors...)
 	if err != nil {
 		return nil, err
 	}
@@ -2131,8 +2131,8 @@ func (c *ClientWithResponses) GetMatrixNoExplodeArrayWithResponse(ctx context.Co
 }
 
 // GetMatrixNoExplodeObjectWithResponse request returning *GetMatrixNoExplodeObjectResponse
-func (c *ClientWithResponses) GetMatrixNoExplodeObjectWithResponse(ctx context.Context, id Object, reqEditors ...RequestEditorFn) (*GetMatrixNoExplodeObjectResponse, error) {
-	rsp, err := c.GetMatrixNoExplodeObject(ctx, id, reqEditors...)
+func (c *ClientWithResponses) GetMatrixNoExplodeObjectWithResponse(ctx context.Context, iD Object, reqEditors ...RequestEditorFn) (*GetMatrixNoExplodeObjectResponse, error) {
+	rsp, err := c.GetMatrixNoExplodeObject(ctx, iD, reqEditors...)
 	if err != nil {
 		return nil, err
 	}
@@ -2212,8 +2212,8 @@ func (c *ClientWithResponses) GetSimplePrimitiveWithResponse(ctx context.Context
 }
 
 // GetStartingWithNumberWithResponse request returning *GetStartingWithNumberResponse
-func (c *ClientWithResponses) GetStartingWithNumberWithResponse(ctx context.Context, n1param string, reqEditors ...RequestEditorFn) (*GetStartingWithNumberResponse, error) {
-	rsp, err := c.GetStartingWithNumber(ctx, n1param, reqEditors...)
+func (c *ClientWithResponses) GetStartingWithNumberWithResponse(ctx context.Context, param string, reqEditors ...RequestEditorFn) (*GetStartingWithNumberResponse, error) {
+	rsp, err := c.GetStartingWithNumber(ctx, param, reqEditors...)
 	if err != nil {
 		return nil, err
 	}
@@ -2565,16 +2565,16 @@ type ServerInterface interface {
 	GetLabelNoExplodeObject(ctx echo.Context, param Object) error
 
 	// (GET /matrixExplodeArray/{.id*})
-	GetMatrixExplodeArray(ctx echo.Context, id []int32) error
+	GetMatrixExplodeArray(ctx echo.Context, iD []int32) error
 
 	// (GET /matrixExplodeObject/{.id*})
-	GetMatrixExplodeObject(ctx echo.Context, id Object) error
+	GetMatrixExplodeObject(ctx echo.Context, iD Object) error
 
 	// (GET /matrixNoExplodeArray/{.id})
-	GetMatrixNoExplodeArray(ctx echo.Context, id []int32) error
+	GetMatrixNoExplodeArray(ctx echo.Context, iD []int32) error
 
 	// (GET /matrixNoExplodeObject/{.id})
-	GetMatrixNoExplodeObject(ctx echo.Context, id Object) error
+	GetMatrixNoExplodeObject(ctx echo.Context, iD Object) error
 
 	// (GET /passThrough/{param})
 	GetPassThrough(ctx echo.Context, param string) error
@@ -2601,7 +2601,7 @@ type ServerInterface interface {
 	GetSimplePrimitive(ctx echo.Context, param int32) error
 
 	// (GET /startingWithNumber/{1param})
-	GetStartingWithNumber(ctx echo.Context, n1param string) error
+	GetStartingWithNumber(ctx echo.Context, param string) error
 }
 
 // ServerInterfaceWrapper converts echo contexts to parameters.
@@ -2721,7 +2721,7 @@ func (w *ServerInterfaceWrapper) GetCookie(ctx echo.Context) error {
 		if err != nil {
 			return echo.NewHTTPError(http.StatusBadRequest, fmt.Sprintf("Invalid format for parameter 1s: %s", err))
 		}
-		params.N1s = &value
+		params.S = &value
 
 	}
 
@@ -2845,18 +2845,18 @@ func (w *ServerInterfaceWrapper) GetHeader(ctx echo.Context) error {
 	}
 	// ------------- Optional header parameter "1-Starting-With-Number" -------------
 	if valueList, found := headers[http.CanonicalHeaderKey("1-Starting-With-Number")]; found {
-		var N1StartingWithNumber string
+		var StartingWithNumber string
 		n := len(valueList)
 		if n != 1 {
 			return echo.NewHTTPError(http.StatusBadRequest, fmt.Sprintf("Expected one value for 1-Starting-With-Number, got %d", n))
 		}
 
-		err = runtime.BindStyledParameterWithLocation("simple", false, "1-Starting-With-Number", runtime.ParamLocationHeader, valueList[0], &N1StartingWithNumber)
+		err = runtime.BindStyledParameterWithLocation("simple", false, "1-Starting-With-Number", runtime.ParamLocationHeader, valueList[0], &StartingWithNumber)
 		if err != nil {
 			return echo.NewHTTPError(http.StatusBadRequest, fmt.Sprintf("Invalid format for parameter 1-Starting-With-Number: %s", err))
 		}
 
-		params.N1StartingWithNumber = &N1StartingWithNumber
+		params.StartingWithNumber = &StartingWithNumber
 	}
 
 	// Invoke the callback with all the unmarshalled arguments
@@ -2932,15 +2932,15 @@ func (w *ServerInterfaceWrapper) GetLabelNoExplodeObject(ctx echo.Context) error
 func (w *ServerInterfaceWrapper) GetMatrixExplodeArray(ctx echo.Context) error {
 	var err error
 	// ------------- Path parameter "id" -------------
-	var id []int32
+	var iD []int32
 
-	err = runtime.BindStyledParameterWithLocation("matrix", true, "id", runtime.ParamLocationPath, ctx.Param("id"), &id)
+	err = runtime.BindStyledParameterWithLocation("matrix", true, "id", runtime.ParamLocationPath, ctx.Param("id"), &iD)
 	if err != nil {
 		return echo.NewHTTPError(http.StatusBadRequest, fmt.Sprintf("Invalid format for parameter id: %s", err))
 	}
 
 	// Invoke the callback with all the unmarshalled arguments
-	err = w.Handler.GetMatrixExplodeArray(ctx, id)
+	err = w.Handler.GetMatrixExplodeArray(ctx, iD)
 	return err
 }
 
@@ -2948,15 +2948,15 @@ func (w *ServerInterfaceWrapper) GetMatrixExplodeArray(ctx echo.Context) error {
 func (w *ServerInterfaceWrapper) GetMatrixExplodeObject(ctx echo.Context) error {
 	var err error
 	// ------------- Path parameter "id" -------------
-	var id Object
+	var iD Object
 
-	err = runtime.BindStyledParameterWithLocation("matrix", true, "id", runtime.ParamLocationPath, ctx.Param("id"), &id)
+	err = runtime.BindStyledParameterWithLocation("matrix", true, "id", runtime.ParamLocationPath, ctx.Param("id"), &iD)
 	if err != nil {
 		return echo.NewHTTPError(http.StatusBadRequest, fmt.Sprintf("Invalid format for parameter id: %s", err))
 	}
 
 	// Invoke the callback with all the unmarshalled arguments
-	err = w.Handler.GetMatrixExplodeObject(ctx, id)
+	err = w.Handler.GetMatrixExplodeObject(ctx, iD)
 	return err
 }
 
@@ -2964,15 +2964,15 @@ func (w *ServerInterfaceWrapper) GetMatrixExplodeObject(ctx echo.Context) error 
 func (w *ServerInterfaceWrapper) GetMatrixNoExplodeArray(ctx echo.Context) error {
 	var err error
 	// ------------- Path parameter "id" -------------
-	var id []int32
+	var iD []int32
 
-	err = runtime.BindStyledParameterWithLocation("matrix", false, "id", runtime.ParamLocationPath, ctx.Param("id"), &id)
+	err = runtime.BindStyledParameterWithLocation("matrix", false, "id", runtime.ParamLocationPath, ctx.Param("id"), &iD)
 	if err != nil {
 		return echo.NewHTTPError(http.StatusBadRequest, fmt.Sprintf("Invalid format for parameter id: %s", err))
 	}
 
 	// Invoke the callback with all the unmarshalled arguments
-	err = w.Handler.GetMatrixNoExplodeArray(ctx, id)
+	err = w.Handler.GetMatrixNoExplodeArray(ctx, iD)
 	return err
 }
 
@@ -2980,15 +2980,15 @@ func (w *ServerInterfaceWrapper) GetMatrixNoExplodeArray(ctx echo.Context) error
 func (w *ServerInterfaceWrapper) GetMatrixNoExplodeObject(ctx echo.Context) error {
 	var err error
 	// ------------- Path parameter "id" -------------
-	var id Object
+	var iD Object
 
-	err = runtime.BindStyledParameterWithLocation("matrix", false, "id", runtime.ParamLocationPath, ctx.Param("id"), &id)
+	err = runtime.BindStyledParameterWithLocation("matrix", false, "id", runtime.ParamLocationPath, ctx.Param("id"), &iD)
 	if err != nil {
 		return echo.NewHTTPError(http.StatusBadRequest, fmt.Sprintf("Invalid format for parameter id: %s", err))
 	}
 
 	// Invoke the callback with all the unmarshalled arguments
-	err = w.Handler.GetMatrixNoExplodeObject(ctx, id)
+	err = w.Handler.GetMatrixNoExplodeObject(ctx, iD)
 	return err
 }
 
@@ -3093,7 +3093,7 @@ func (w *ServerInterfaceWrapper) GetQueryForm(ctx echo.Context) error {
 
 	// ------------- Optional query parameter "1s" -------------
 
-	err = runtime.BindQueryParameter("form", true, false, "1s", ctx.QueryParams(), &params.N1s)
+	err = runtime.BindQueryParameter("form", true, false, "1s", ctx.QueryParams(), &params.S)
 	if err != nil {
 		return echo.NewHTTPError(http.StatusBadRequest, fmt.Sprintf("Invalid format for parameter 1s: %s", err))
 	}
@@ -3187,12 +3187,12 @@ func (w *ServerInterfaceWrapper) GetSimplePrimitive(ctx echo.Context) error {
 func (w *ServerInterfaceWrapper) GetStartingWithNumber(ctx echo.Context) error {
 	var err error
 	// ------------- Path parameter "1param" -------------
-	var n1param string
+	var param string
 
-	n1param = ctx.Param("1param")
+	param = ctx.Param("1param")
 
 	// Invoke the callback with all the unmarshalled arguments
-	err = w.Handler.GetStartingWithNumber(ctx, n1param)
+	err = w.Handler.GetStartingWithNumber(ctx, param)
 	return err
 }
 

--- a/internal/test/schemas/schemas.gen.go
+++ b/internal/test/schemas/schemas.gen.go
@@ -37,7 +37,7 @@ const (
 )
 
 // This schema name starts with a number
-type N5StartsWithNumber map[string]interface{}
+type StartsWithNumber map[string]interface{}
 
 // AnyType1 defines model for AnyType1.
 type AnyType1 interface{}
@@ -183,7 +183,7 @@ type ClientInterface interface {
 	GetIssues375(ctx context.Context, reqEditors ...RequestEditorFn) (*http.Response, error)
 
 	// Issue41 request
-	Issue41(ctx context.Context, n1param N5StartsWithNumber, reqEditors ...RequestEditorFn) (*http.Response, error)
+	Issue41(ctx context.Context, param StartsWithNumber, reqEditors ...RequestEditorFn) (*http.Response, error)
 
 	// Issue9 request with any body
 	Issue9WithBody(ctx context.Context, params *Issue9Params, contentType string, body io.Reader, reqEditors ...RequestEditorFn) (*http.Response, error)
@@ -275,8 +275,8 @@ func (c *Client) GetIssues375(ctx context.Context, reqEditors ...RequestEditorFn
 	return c.Client.Do(req)
 }
 
-func (c *Client) Issue41(ctx context.Context, n1param N5StartsWithNumber, reqEditors ...RequestEditorFn) (*http.Response, error) {
-	req, err := NewIssue41Request(c.Server, n1param)
+func (c *Client) Issue41(ctx context.Context, param StartsWithNumber, reqEditors ...RequestEditorFn) (*http.Response, error) {
+	req, err := NewIssue41Request(c.Server, param)
 	if err != nil {
 		return nil, err
 	}
@@ -501,12 +501,12 @@ func NewGetIssues375Request(server string) (*http.Request, error) {
 }
 
 // NewIssue41Request generates requests for Issue41
-func NewIssue41Request(server string, n1param N5StartsWithNumber) (*http.Request, error) {
+func NewIssue41Request(server string, param StartsWithNumber) (*http.Request, error) {
 	var err error
 
 	var pathParam0 string
 
-	pathParam0, err = runtime.StyleParamWithLocation("simple", false, "1param", runtime.ParamLocationPath, n1param)
+	pathParam0, err = runtime.StyleParamWithLocation("simple", false, "1param", runtime.ParamLocationPath, param)
 	if err != nil {
 		return nil, err
 	}
@@ -654,7 +654,7 @@ type ClientWithResponsesInterface interface {
 	GetIssues375WithResponse(ctx context.Context, reqEditors ...RequestEditorFn) (*GetIssues375Response, error)
 
 	// Issue41 request
-	Issue41WithResponse(ctx context.Context, n1param N5StartsWithNumber, reqEditors ...RequestEditorFn) (*Issue41Response, error)
+	Issue41WithResponse(ctx context.Context, param StartsWithNumber, reqEditors ...RequestEditorFn) (*Issue41Response, error)
 
 	// Issue9 request with any body
 	Issue9WithBodyWithResponse(ctx context.Context, params *Issue9Params, contentType string, body io.Reader, reqEditors ...RequestEditorFn) (*Issue9Response, error)
@@ -665,7 +665,7 @@ type ClientWithResponsesInterface interface {
 type EnsureEverythingIsReferencedResponse struct {
 	Body         []byte
 	HTTPResponse *http.Response
-	JSON200      *struct {
+	JSON         *struct {
 		AnyType1 *AnyType1 `json:"anyType1,omitempty"`
 
 		// AnyType2 represents any type.
@@ -695,9 +695,9 @@ func (r EnsureEverythingIsReferencedResponse) StatusCode() int {
 type Issue127Response struct {
 	Body         []byte
 	HTTPResponse *http.Response
-	JSON200      *GenericObject
-	XML200       *GenericObject
-	YAML200      *GenericObject
+	JSON         *GenericObject
+	XML          *GenericObject
+	YAML         *GenericObject
 	JSONDefault  *GenericObject
 }
 
@@ -783,7 +783,7 @@ func (r Issue30Response) StatusCode() int {
 type GetIssues375Response struct {
 	Body         []byte
 	HTTPResponse *http.Response
-	JSON200      *EnumInObjInArray
+	JSON         *EnumInObjInArray
 }
 
 // Status returns HTTPResponse.Status
@@ -907,8 +907,8 @@ func (c *ClientWithResponses) GetIssues375WithResponse(ctx context.Context, reqE
 }
 
 // Issue41WithResponse request returning *Issue41Response
-func (c *ClientWithResponses) Issue41WithResponse(ctx context.Context, n1param N5StartsWithNumber, reqEditors ...RequestEditorFn) (*Issue41Response, error) {
-	rsp, err := c.Issue41(ctx, n1param, reqEditors...)
+func (c *ClientWithResponses) Issue41WithResponse(ctx context.Context, param StartsWithNumber, reqEditors ...RequestEditorFn) (*Issue41Response, error) {
+	rsp, err := c.Issue41(ctx, param, reqEditors...)
 	if err != nil {
 		return nil, err
 	}
@@ -959,7 +959,7 @@ func ParseEnsureEverythingIsReferencedResponse(rsp *http.Response) (*EnsureEvery
 		if err := json.Unmarshal(bodyBytes, &dest); err != nil {
 			return nil, err
 		}
-		response.JSON200 = &dest
+		response.JSON = &dest
 
 	}
 
@@ -985,7 +985,7 @@ func ParseIssue127Response(rsp *http.Response) (*Issue127Response, error) {
 		if err := json.Unmarshal(bodyBytes, &dest); err != nil {
 			return nil, err
 		}
-		response.JSON200 = &dest
+		response.JSON = &dest
 
 	case strings.Contains(rsp.Header.Get("Content-Type"), "json") && true:
 		var dest GenericObject
@@ -999,14 +999,14 @@ func ParseIssue127Response(rsp *http.Response) (*Issue127Response, error) {
 		if err := xml.Unmarshal(bodyBytes, &dest); err != nil {
 			return nil, err
 		}
-		response.XML200 = &dest
+		response.XML = &dest
 
 	case strings.Contains(rsp.Header.Get("Content-Type"), "yaml") && rsp.StatusCode == 200:
 		var dest GenericObject
 		if err := yaml.Unmarshal(bodyBytes, &dest); err != nil {
 			return nil, err
 		}
-		response.YAML200 = &dest
+		response.YAML = &dest
 
 	case rsp.StatusCode == 200:
 	// Content-type (text/markdown) unsupported
@@ -1086,7 +1086,7 @@ func ParseGetIssues375Response(rsp *http.Response) (*GetIssues375Response, error
 		if err := json.Unmarshal(bodyBytes, &dest); err != nil {
 			return nil, err
 		}
-		response.JSON200 = &dest
+		response.JSON = &dest
 
 	}
 
@@ -1147,7 +1147,7 @@ type ServerInterface interface {
 	GetIssues375(ctx echo.Context) error
 
 	// (GET /issues/41/{1param})
-	Issue41(ctx echo.Context, n1param N5StartsWithNumber) error
+	Issue41(ctx echo.Context, param StartsWithNumber) error
 
 	// (GET /issues/9)
 	Issue9(ctx echo.Context, params Issue9Params) error
@@ -1242,9 +1242,9 @@ func (w *ServerInterfaceWrapper) GetIssues375(ctx echo.Context) error {
 func (w *ServerInterfaceWrapper) Issue41(ctx echo.Context) error {
 	var err error
 	// ------------- Path parameter "1param" -------------
-	var n1param N5StartsWithNumber
+	var param StartsWithNumber
 
-	err = runtime.BindStyledParameterWithLocation("simple", false, "1param", runtime.ParamLocationPath, ctx.Param("1param"), &n1param)
+	err = runtime.BindStyledParameterWithLocation("simple", false, "1param", runtime.ParamLocationPath, ctx.Param("1param"), &param)
 	if err != nil {
 		return echo.NewHTTPError(http.StatusBadRequest, fmt.Sprintf("Invalid format for parameter 1param: %s", err))
 	}
@@ -1252,7 +1252,7 @@ func (w *ServerInterfaceWrapper) Issue41(ctx echo.Context) error {
 	ctx.Set(Access_tokenScopes, []string{""})
 
 	// Invoke the callback with all the unmarshalled arguments
-	err = w.Handler.Issue41(ctx, n1param)
+	err = w.Handler.Issue41(ctx, param)
 	return err
 }
 

--- a/internal/test/server/server.gen.go
+++ b/internal/test/server/server.gen.go
@@ -114,7 +114,7 @@ type CreateResource2Params struct {
 
 // UpdateResource3JSONBody defines parameters for UpdateResource3.
 type UpdateResource3JSONBody struct {
-	Id   *int    `json:"id,omitempty"`
+	ID   *int    `json:"id,omitempty"`
 	Name *string `json:"name,omitempty"`
 }
 

--- a/pkg/codegen/utils.go
+++ b/pkg/codegen/utils.go
@@ -23,6 +23,7 @@ import (
 	"unicode"
 
 	"github.com/getkin/kin-openapi/openapi3"
+	"github.com/kenshaw/snaker"
 )
 
 var pathParamRE *regexp.Regexp
@@ -52,38 +53,10 @@ func LowercaseFirstCharacter(str string) string {
 	return string(runes)
 }
 
-// This function will convert query-arg style strings to CamelCase. We will
-// use `., -, +, :, ;, _, ~, ' ', (, ), {, }, [, ]` as valid delimiters for words.
-// So, "word.word-word+word:word;word_word~word word(word)word{word}[word]"
-// would be converted to WordWordWordWordWordWordWordWordWordWordWordWordWord
+// ToCamelCase converts a string to camel case
+// with proper Go initialisms.
 func ToCamelCase(str string) string {
-	separators := "-#@!$&=.+:;_~ (){}[]"
-	s := strings.Trim(str, " ")
-
-	n := ""
-	capNext := true
-	for _, v := range s {
-		if unicode.IsUpper(v) {
-			n += string(v)
-		}
-		if unicode.IsDigit(v) {
-			n += string(v)
-		}
-		if unicode.IsLower(v) {
-			if capNext {
-				n += strings.ToUpper(string(v))
-			} else {
-				n += string(v)
-			}
-		}
-
-		if strings.ContainsRune(separators, v) {
-			capNext = true
-		} else {
-			capNext = false
-		}
-	}
-	return n
+	return snaker.ForceCamelIdentifier(str)
 }
 
 // This function returns the keys of the given SchemaRef dictionary in sorted


### PR DESCRIPTION
Previously, Go type names were generated with a naive CamelCase conversion. Although Go follows CamelCase naming conventions, there are also formatting rules around initialisms.

For example, goapi-gen could produces something like productId or PayloadXml, where the correct names would be productID and PayloadXML respectively.

Closes #2 