### PR TITLE
chore: adds previous tests from Travis as github action

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -1,18 +1,9 @@
-name: Continuous Integration
+name: Test Code Generation
 
-on:
-  push:
-    branches:
-      - main
-      - master
-  pull_request:
+on: [push, pull_request]
 
 jobs:
   Test:
-    strategy:
-      matrix:
-        go-version: [1.16.x, 1.17.x]
-
     runs-on: ubuntu-latest
     steps:
       - name: Checkout code
@@ -21,7 +12,7 @@ jobs:
       - name: Install Go
         uses: actions/setup-go@v2
         with:
-          go-version: ${{ matrix.go-version }}
+          go-version: 1.17.x
 
       - name: Setup cache
         uses: actions/cache@v2


### PR DESCRIPTION
# Changes

- creates github action to test go source and code generation
- adds automated testing for go v1.17,v1.16
- adds automated testing for ubuntu and windows
- sets up dependency caching in github action to remove repeated dependency installation

fixes #10 