### PR TITLE
Fix invalid go type names

### DIFF
--- a/README.md
+++ b/README.md
@@ -127,6 +127,7 @@ type FindPetsParams struct {
 ```
 
 ### Registering handlers
+
 You can register handlers when generating a server with `-generate server`.
 
 <details><summary><code>Chi</code></summary>

--- a/examples/petstore-expanded/chi/api/petstore.gen.go
+++ b/examples/petstore-expanded/chi/api/petstore.gen.go
@@ -99,7 +99,7 @@ func (siw *ServerInterfaceWrapper) FindPets(w http.ResponseWriter, r *http.Reque
 	}
 
 	if err := runtime.BindQueryParameter("form", true, false, "tags", r.URL.Query(), &params.Tags); err != nil {
-		err = fmt.Errorf("Invalid format for parameter tags: %w", err)
+		err = fmt.Errorf("invalid format for parameter tags: %w", err)
 		siw.ErrorHandlerFunc(w, r, &InvalidParamFormatError{err})
 		return
 	}
@@ -110,7 +110,7 @@ func (siw *ServerInterfaceWrapper) FindPets(w http.ResponseWriter, r *http.Reque
 	}
 
 	if err := runtime.BindQueryParameter("form", true, false, "limit", r.URL.Query(), &params.Limit); err != nil {
-		err = fmt.Errorf("Invalid format for parameter limit: %w", err)
+		err = fmt.Errorf("invalid format for parameter limit: %w", err)
 		siw.ErrorHandlerFunc(w, r, &InvalidParamFormatError{err})
 		return
 	}
@@ -149,7 +149,7 @@ func (siw *ServerInterfaceWrapper) DeletePet(w http.ResponseWriter, r *http.Requ
 	var id int64
 
 	if err := runtime.BindStyledParameter("simple", false, "id", chi.URLParam(r, "id"), &id); err != nil {
-		err = fmt.Errorf("Invalid format for parameter id: %w", err)
+		err = fmt.Errorf("invalid format for parameter id: %w", err)
 		siw.ErrorHandlerFunc(w, r, &InvalidParamFormatError{err})
 		return
 	}
@@ -173,7 +173,7 @@ func (siw *ServerInterfaceWrapper) FindPetByID(w http.ResponseWriter, r *http.Re
 	var id int64
 
 	if err := runtime.BindStyledParameter("simple", false, "id", chi.URLParam(r, "id"), &id); err != nil {
-		err = fmt.Errorf("Invalid format for parameter id: %w", err)
+		err = fmt.Errorf("invalid format for parameter id: %w", err)
 		siw.ErrorHandlerFunc(w, r, &InvalidParamFormatError{err})
 		return
 	}

--- a/internal/test/client/client.gen.go
+++ b/internal/test/client/client.gen.go
@@ -22,7 +22,7 @@ import (
 )
 
 const (
-	OpenIdScopes = "OpenId.Scopes"
+	OpenIDScopes = "OpenId.Scopes"
 )
 
 // SchemaObject defines model for SchemaObject.
@@ -958,7 +958,7 @@ func (siw *ServerInterfaceWrapper) PostJSON(w http.ResponseWriter, r *http.Reque
 func (siw *ServerInterfaceWrapper) GetJSON(w http.ResponseWriter, r *http.Request) {
 	ctx := r.Context()
 
-	ctx = context.WithValue(ctx, OpenIdScopes, []string{"json.read", "json.admin"})
+	ctx = context.WithValue(ctx, OpenIDScopes, []string{"json.read", "json.admin"})
 
 	var handler = http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		siw.Handler.GetJSON(w, r)
@@ -1005,7 +1005,7 @@ func (siw *ServerInterfaceWrapper) GetOther(w http.ResponseWriter, r *http.Reque
 func (siw *ServerInterfaceWrapper) GetJSONWithTrailingSlash(w http.ResponseWriter, r *http.Request) {
 	ctx := r.Context()
 
-	ctx = context.WithValue(ctx, OpenIdScopes, []string{"json.read", "json.admin"})
+	ctx = context.WithValue(ctx, OpenIDScopes, []string{"json.read", "json.admin"})
 
 	var handler = http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		siw.Handler.GetJSONWithTrailingSlash(w, r)

--- a/internal/test/components/components.gen.go
+++ b/internal/test/components/components.gen.go
@@ -1319,13 +1319,13 @@ func (siw *ServerInterfaceWrapper) ParamsWithAddProps(w http.ResponseWriter, r *
 	if paramValue := r.URL.Query().Get("p1"); paramValue != "" {
 
 	} else {
-		err := fmt.Errorf("Query argument p1 is required, but not found")
+		err := fmt.Errorf("query argument p1 is required, but not found")
 		siw.ErrorHandlerFunc(w, r, &RequiredParamError{err})
 		return
 	}
 
 	if err := runtime.BindQueryParameter("simple", true, true, "p1", r.URL.Query(), &params.P1); err != nil {
-		err = fmt.Errorf("Invalid format for parameter p1: %w", err)
+		err = fmt.Errorf("invalid format for parameter p1: %w", err)
 		siw.ErrorHandlerFunc(w, r, &InvalidParamFormatError{err})
 		return
 	}
@@ -1334,13 +1334,13 @@ func (siw *ServerInterfaceWrapper) ParamsWithAddProps(w http.ResponseWriter, r *
 	if paramValue := r.URL.Query().Get("p2"); paramValue != "" {
 
 	} else {
-		err := fmt.Errorf("Query argument p2 is required, but not found")
+		err := fmt.Errorf("query argument p2 is required, but not found")
 		siw.ErrorHandlerFunc(w, r, &RequiredParamError{err})
 		return
 	}
 
 	if err := runtime.BindQueryParameter("form", true, true, "p2", r.URL.Query(), &params.P2); err != nil {
-		err = fmt.Errorf("Invalid format for parameter p2: %w", err)
+		err = fmt.Errorf("invalid format for parameter p2: %w", err)
 		siw.ErrorHandlerFunc(w, r, &InvalidParamFormatError{err})
 		return
 	}

--- a/internal/test/parameters/parameters.gen.go
+++ b/internal/test/parameters/parameters.gen.go
@@ -2622,7 +2622,7 @@ func (siw *ServerInterfaceWrapper) GetContentObject(w http.ResponseWriter, r *ht
 	var param ComplexObject
 
 	if err := json.Unmarshal([]byte(chi.URLParam(r, "param")), &param); err != nil {
-		err = fmt.Errorf("Error unmarshaling parameter 'param' as JSON: %w", err)
+		err = fmt.Errorf("error unmarshaling parameter 'param' as JSON: %w", err)
 		siw.ErrorHandlerFunc(w, r, &UnmarshalingParamError{err})
 		return
 	}
@@ -2648,7 +2648,7 @@ func (siw *ServerInterfaceWrapper) GetCookie(w http.ResponseWriter, r *http.Requ
 	if cookie, err := r.Cookie("p"); err == nil {
 		var value int32
 		if err := runtime.BindStyledParameter("simple", false, "p", cookie.Value, &value); err != nil {
-			err = fmt.Errorf("Invalid format for parameter p: %w", err)
+			err = fmt.Errorf("invalid format for parameter p: %w", err)
 			siw.ErrorHandlerFunc(w, r, &InvalidParamFormatError{err})
 			return
 		}
@@ -2659,7 +2659,7 @@ func (siw *ServerInterfaceWrapper) GetCookie(w http.ResponseWriter, r *http.Requ
 	if cookie, err := r.Cookie("ep"); err == nil {
 		var value int32
 		if err := runtime.BindStyledParameter("simple", true, "ep", cookie.Value, &value); err != nil {
-			err = fmt.Errorf("Invalid format for parameter ep: %w", err)
+			err = fmt.Errorf("invalid format for parameter ep: %w", err)
 			siw.ErrorHandlerFunc(w, r, &InvalidParamFormatError{err})
 			return
 		}
@@ -2670,7 +2670,7 @@ func (siw *ServerInterfaceWrapper) GetCookie(w http.ResponseWriter, r *http.Requ
 	if cookie, err := r.Cookie("ea"); err == nil {
 		var value []int32
 		if err := runtime.BindStyledParameter("simple", true, "ea", cookie.Value, &value); err != nil {
-			err = fmt.Errorf("Invalid format for parameter ea: %w", err)
+			err = fmt.Errorf("invalid format for parameter ea: %w", err)
 			siw.ErrorHandlerFunc(w, r, &InvalidParamFormatError{err})
 			return
 		}
@@ -2681,7 +2681,7 @@ func (siw *ServerInterfaceWrapper) GetCookie(w http.ResponseWriter, r *http.Requ
 	if cookie, err := r.Cookie("a"); err == nil {
 		var value []int32
 		if err := runtime.BindStyledParameter("simple", false, "a", cookie.Value, &value); err != nil {
-			err = fmt.Errorf("Invalid format for parameter a: %w", err)
+			err = fmt.Errorf("invalid format for parameter a: %w", err)
 			siw.ErrorHandlerFunc(w, r, &InvalidParamFormatError{err})
 			return
 		}
@@ -2692,7 +2692,7 @@ func (siw *ServerInterfaceWrapper) GetCookie(w http.ResponseWriter, r *http.Requ
 	if cookie, err := r.Cookie("eo"); err == nil {
 		var value Object
 		if err := runtime.BindStyledParameter("simple", true, "eo", cookie.Value, &value); err != nil {
-			err = fmt.Errorf("Invalid format for parameter eo: %w", err)
+			err = fmt.Errorf("invalid format for parameter eo: %w", err)
 			siw.ErrorHandlerFunc(w, r, &InvalidParamFormatError{err})
 			return
 		}
@@ -2703,7 +2703,7 @@ func (siw *ServerInterfaceWrapper) GetCookie(w http.ResponseWriter, r *http.Requ
 	if cookie, err := r.Cookie("o"); err == nil {
 		var value Object
 		if err := runtime.BindStyledParameter("simple", false, "o", cookie.Value, &value); err != nil {
-			err = fmt.Errorf("Invalid format for parameter o: %w", err)
+			err = fmt.Errorf("invalid format for parameter o: %w", err)
 			siw.ErrorHandlerFunc(w, r, &InvalidParamFormatError{err})
 			return
 		}
@@ -2716,14 +2716,14 @@ func (siw *ServerInterfaceWrapper) GetCookie(w http.ResponseWriter, r *http.Requ
 		var decoded string
 		decoded, err := url.QueryUnescape(cookie.Value)
 		if err != nil {
-			err = fmt.Errorf("Error unescaping cookie parameter 'co'")
+			err = fmt.Errorf("error unescaping cookie parameter 'co'")
 			siw.ErrorHandlerFunc(w, r, &UnescapedCookieParamError{err})
 			return
 		}
 
 		err = json.Unmarshal([]byte(decoded), &value)
 		if err != nil {
-			err = fmt.Errorf("Error unmarshaling parameter 'co' as JSON: %w", err)
+			err = fmt.Errorf("error unmarshaling parameter 'co' as JSON: %w", err)
 			siw.ErrorHandlerFunc(w, r, &UnmarshalingParamError{err})
 			return
 		}
@@ -2735,7 +2735,7 @@ func (siw *ServerInterfaceWrapper) GetCookie(w http.ResponseWriter, r *http.Requ
 	if cookie, err := r.Cookie("1s"); err == nil {
 		var value string
 		if err := runtime.BindStyledParameter("simple", true, "1s", cookie.Value, &value); err != nil {
-			err = fmt.Errorf("Invalid format for parameter 1s: %w", err)
+			err = fmt.Errorf("invalid format for parameter 1s: %w", err)
 			siw.ErrorHandlerFunc(w, r, &InvalidParamFormatError{err})
 			return
 		}
@@ -2768,13 +2768,13 @@ func (siw *ServerInterfaceWrapper) GetHeader(w http.ResponseWriter, r *http.Requ
 		var XPrimitive int32
 		n := len(valueList)
 		if n != 1 {
-			err := fmt.Errorf("Expected one value for X-Primitive, got %d", n)
+			err := fmt.Errorf("expected one value for X-Primitive, got %d", n)
 			siw.ErrorHandlerFunc(w, r, &TooManyValuesForParamError{err})
 			return
 		}
 
 		if err := runtime.BindStyledParameterWithLocation("simple", false, "X-Primitive", runtime.ParamLocationHeader, valueList[0], &XPrimitive); err != nil {
-			err = fmt.Errorf("Invalid format for parameter X-Primitive: %w", err)
+			err = fmt.Errorf("invalid format for parameter X-Primitive: %w", err)
 			siw.ErrorHandlerFunc(w, r, &InvalidParamFormatError{err})
 			return
 		}
@@ -2788,13 +2788,13 @@ func (siw *ServerInterfaceWrapper) GetHeader(w http.ResponseWriter, r *http.Requ
 		var XPrimitiveExploded int32
 		n := len(valueList)
 		if n != 1 {
-			err := fmt.Errorf("Expected one value for X-Primitive-Exploded, got %d", n)
+			err := fmt.Errorf("expected one value for X-Primitive-Exploded, got %d", n)
 			siw.ErrorHandlerFunc(w, r, &TooManyValuesForParamError{err})
 			return
 		}
 
 		if err := runtime.BindStyledParameterWithLocation("simple", true, "X-Primitive-Exploded", runtime.ParamLocationHeader, valueList[0], &XPrimitiveExploded); err != nil {
-			err = fmt.Errorf("Invalid format for parameter X-Primitive-Exploded: %w", err)
+			err = fmt.Errorf("invalid format for parameter X-Primitive-Exploded: %w", err)
 			siw.ErrorHandlerFunc(w, r, &InvalidParamFormatError{err})
 			return
 		}
@@ -2808,13 +2808,13 @@ func (siw *ServerInterfaceWrapper) GetHeader(w http.ResponseWriter, r *http.Requ
 		var XArrayExploded []int32
 		n := len(valueList)
 		if n != 1 {
-			err := fmt.Errorf("Expected one value for X-Array-Exploded, got %d", n)
+			err := fmt.Errorf("expected one value for X-Array-Exploded, got %d", n)
 			siw.ErrorHandlerFunc(w, r, &TooManyValuesForParamError{err})
 			return
 		}
 
 		if err := runtime.BindStyledParameterWithLocation("simple", true, "X-Array-Exploded", runtime.ParamLocationHeader, valueList[0], &XArrayExploded); err != nil {
-			err = fmt.Errorf("Invalid format for parameter X-Array-Exploded: %w", err)
+			err = fmt.Errorf("invalid format for parameter X-Array-Exploded: %w", err)
 			siw.ErrorHandlerFunc(w, r, &InvalidParamFormatError{err})
 			return
 		}
@@ -2828,13 +2828,13 @@ func (siw *ServerInterfaceWrapper) GetHeader(w http.ResponseWriter, r *http.Requ
 		var XArray []int32
 		n := len(valueList)
 		if n != 1 {
-			err := fmt.Errorf("Expected one value for X-Array, got %d", n)
+			err := fmt.Errorf("expected one value for X-Array, got %d", n)
 			siw.ErrorHandlerFunc(w, r, &TooManyValuesForParamError{err})
 			return
 		}
 
 		if err := runtime.BindStyledParameterWithLocation("simple", false, "X-Array", runtime.ParamLocationHeader, valueList[0], &XArray); err != nil {
-			err = fmt.Errorf("Invalid format for parameter X-Array: %w", err)
+			err = fmt.Errorf("invalid format for parameter X-Array: %w", err)
 			siw.ErrorHandlerFunc(w, r, &InvalidParamFormatError{err})
 			return
 		}
@@ -2848,13 +2848,13 @@ func (siw *ServerInterfaceWrapper) GetHeader(w http.ResponseWriter, r *http.Requ
 		var XObjectExploded Object
 		n := len(valueList)
 		if n != 1 {
-			err := fmt.Errorf("Expected one value for X-Object-Exploded, got %d", n)
+			err := fmt.Errorf("expected one value for X-Object-Exploded, got %d", n)
 			siw.ErrorHandlerFunc(w, r, &TooManyValuesForParamError{err})
 			return
 		}
 
 		if err := runtime.BindStyledParameterWithLocation("simple", true, "X-Object-Exploded", runtime.ParamLocationHeader, valueList[0], &XObjectExploded); err != nil {
-			err = fmt.Errorf("Invalid format for parameter X-Object-Exploded: %w", err)
+			err = fmt.Errorf("invalid format for parameter X-Object-Exploded: %w", err)
 			siw.ErrorHandlerFunc(w, r, &InvalidParamFormatError{err})
 			return
 		}
@@ -2868,13 +2868,13 @@ func (siw *ServerInterfaceWrapper) GetHeader(w http.ResponseWriter, r *http.Requ
 		var XObject Object
 		n := len(valueList)
 		if n != 1 {
-			err := fmt.Errorf("Expected one value for X-Object, got %d", n)
+			err := fmt.Errorf("expected one value for X-Object, got %d", n)
 			siw.ErrorHandlerFunc(w, r, &TooManyValuesForParamError{err})
 			return
 		}
 
 		if err := runtime.BindStyledParameterWithLocation("simple", false, "X-Object", runtime.ParamLocationHeader, valueList[0], &XObject); err != nil {
-			err = fmt.Errorf("Invalid format for parameter X-Object: %w", err)
+			err = fmt.Errorf("invalid format for parameter X-Object: %w", err)
 			siw.ErrorHandlerFunc(w, r, &InvalidParamFormatError{err})
 			return
 		}
@@ -2888,13 +2888,13 @@ func (siw *ServerInterfaceWrapper) GetHeader(w http.ResponseWriter, r *http.Requ
 		var XComplexObject ComplexObject
 		n := len(valueList)
 		if n != 1 {
-			err := fmt.Errorf("Expected one value for X-Complex-Object, got %d", n)
+			err := fmt.Errorf("expected one value for X-Complex-Object, got %d", n)
 			siw.ErrorHandlerFunc(w, r, &TooManyValuesForParamError{err})
 			return
 		}
 
 		if err := json.Unmarshal([]byte(valueList[0]), &XComplexObject); err != nil {
-			err = fmt.Errorf("Error unmarshaling parameter 'X-Complex-Object' as JSON: %w", err)
+			err = fmt.Errorf("error unmarshaling parameter 'X-Complex-Object' as JSON: %w", err)
 			siw.ErrorHandlerFunc(w, r, &UnmarshalingParamError{err})
 			return
 		}
@@ -2908,13 +2908,13 @@ func (siw *ServerInterfaceWrapper) GetHeader(w http.ResponseWriter, r *http.Requ
 		var N1StartingWithNumber string
 		n := len(valueList)
 		if n != 1 {
-			err := fmt.Errorf("Expected one value for 1-Starting-With-Number, got %d", n)
+			err := fmt.Errorf("expected one value for 1-Starting-With-Number, got %d", n)
 			siw.ErrorHandlerFunc(w, r, &TooManyValuesForParamError{err})
 			return
 		}
 
 		if err := runtime.BindStyledParameterWithLocation("simple", false, "1-Starting-With-Number", runtime.ParamLocationHeader, valueList[0], &N1StartingWithNumber); err != nil {
-			err = fmt.Errorf("Invalid format for parameter 1-Starting-With-Number: %w", err)
+			err = fmt.Errorf("invalid format for parameter 1-Starting-With-Number: %w", err)
 			siw.ErrorHandlerFunc(w, r, &InvalidParamFormatError{err})
 			return
 		}
@@ -2942,7 +2942,7 @@ func (siw *ServerInterfaceWrapper) GetLabelExplodeArray(w http.ResponseWriter, r
 	var param []int32
 
 	if err := runtime.BindStyledParameter("label", true, "param", chi.URLParam(r, "param"), &param); err != nil {
-		err = fmt.Errorf("Invalid format for parameter param: %w", err)
+		err = fmt.Errorf("invalid format for parameter param: %w", err)
 		siw.ErrorHandlerFunc(w, r, &InvalidParamFormatError{err})
 		return
 	}
@@ -2966,7 +2966,7 @@ func (siw *ServerInterfaceWrapper) GetLabelExplodeObject(w http.ResponseWriter, 
 	var param Object
 
 	if err := runtime.BindStyledParameter("label", true, "param", chi.URLParam(r, "param"), &param); err != nil {
-		err = fmt.Errorf("Invalid format for parameter param: %w", err)
+		err = fmt.Errorf("invalid format for parameter param: %w", err)
 		siw.ErrorHandlerFunc(w, r, &InvalidParamFormatError{err})
 		return
 	}
@@ -2990,7 +2990,7 @@ func (siw *ServerInterfaceWrapper) GetLabelNoExplodeArray(w http.ResponseWriter,
 	var param []int32
 
 	if err := runtime.BindStyledParameter("label", false, "param", chi.URLParam(r, "param"), &param); err != nil {
-		err = fmt.Errorf("Invalid format for parameter param: %w", err)
+		err = fmt.Errorf("invalid format for parameter param: %w", err)
 		siw.ErrorHandlerFunc(w, r, &InvalidParamFormatError{err})
 		return
 	}
@@ -3014,7 +3014,7 @@ func (siw *ServerInterfaceWrapper) GetLabelNoExplodeObject(w http.ResponseWriter
 	var param Object
 
 	if err := runtime.BindStyledParameter("label", false, "param", chi.URLParam(r, "param"), &param); err != nil {
-		err = fmt.Errorf("Invalid format for parameter param: %w", err)
+		err = fmt.Errorf("invalid format for parameter param: %w", err)
 		siw.ErrorHandlerFunc(w, r, &InvalidParamFormatError{err})
 		return
 	}
@@ -3038,7 +3038,7 @@ func (siw *ServerInterfaceWrapper) GetMatrixExplodeArray(w http.ResponseWriter, 
 	var id []int32
 
 	if err := runtime.BindStyledParameter("matrix", true, "id", chi.URLParam(r, "id"), &id); err != nil {
-		err = fmt.Errorf("Invalid format for parameter id: %w", err)
+		err = fmt.Errorf("invalid format for parameter id: %w", err)
 		siw.ErrorHandlerFunc(w, r, &InvalidParamFormatError{err})
 		return
 	}
@@ -3062,7 +3062,7 @@ func (siw *ServerInterfaceWrapper) GetMatrixExplodeObject(w http.ResponseWriter,
 	var id Object
 
 	if err := runtime.BindStyledParameter("matrix", true, "id", chi.URLParam(r, "id"), &id); err != nil {
-		err = fmt.Errorf("Invalid format for parameter id: %w", err)
+		err = fmt.Errorf("invalid format for parameter id: %w", err)
 		siw.ErrorHandlerFunc(w, r, &InvalidParamFormatError{err})
 		return
 	}
@@ -3086,7 +3086,7 @@ func (siw *ServerInterfaceWrapper) GetMatrixNoExplodeArray(w http.ResponseWriter
 	var id []int32
 
 	if err := runtime.BindStyledParameter("matrix", false, "id", chi.URLParam(r, "id"), &id); err != nil {
-		err = fmt.Errorf("Invalid format for parameter id: %w", err)
+		err = fmt.Errorf("invalid format for parameter id: %w", err)
 		siw.ErrorHandlerFunc(w, r, &InvalidParamFormatError{err})
 		return
 	}
@@ -3110,7 +3110,7 @@ func (siw *ServerInterfaceWrapper) GetMatrixNoExplodeObject(w http.ResponseWrite
 	var id Object
 
 	if err := runtime.BindStyledParameter("matrix", false, "id", chi.URLParam(r, "id"), &id); err != nil {
-		err = fmt.Errorf("Invalid format for parameter id: %w", err)
+		err = fmt.Errorf("invalid format for parameter id: %w", err)
 		siw.ErrorHandlerFunc(w, r, &InvalidParamFormatError{err})
 		return
 	}
@@ -3157,13 +3157,13 @@ func (siw *ServerInterfaceWrapper) GetDeepObject(w http.ResponseWriter, r *http.
 	if paramValue := r.URL.Query().Get("deepObj"); paramValue != "" {
 
 	} else {
-		err := fmt.Errorf("Query argument deepObj is required, but not found")
+		err := fmt.Errorf("query argument deepObj is required, but not found")
 		siw.ErrorHandlerFunc(w, r, &RequiredParamError{err})
 		return
 	}
 
 	if err := runtime.BindQueryParameter("deepObject", true, true, "deepObj", r.URL.Query(), &params.DeepObj); err != nil {
-		err = fmt.Errorf("Invalid format for parameter deepObj: %w", err)
+		err = fmt.Errorf("invalid format for parameter deepObj: %w", err)
 		siw.ErrorHandlerFunc(w, r, &InvalidParamFormatError{err})
 		return
 	}
@@ -3192,7 +3192,7 @@ func (siw *ServerInterfaceWrapper) GetQueryForm(w http.ResponseWriter, r *http.R
 	}
 
 	if err := runtime.BindQueryParameter("form", true, false, "ea", r.URL.Query(), &params.Ea); err != nil {
-		err = fmt.Errorf("Invalid format for parameter ea: %w", err)
+		err = fmt.Errorf("invalid format for parameter ea: %w", err)
 		siw.ErrorHandlerFunc(w, r, &InvalidParamFormatError{err})
 		return
 	}
@@ -3203,7 +3203,7 @@ func (siw *ServerInterfaceWrapper) GetQueryForm(w http.ResponseWriter, r *http.R
 	}
 
 	if err := runtime.BindQueryParameter("form", false, false, "a", r.URL.Query(), &params.A); err != nil {
-		err = fmt.Errorf("Invalid format for parameter a: %w", err)
+		err = fmt.Errorf("invalid format for parameter a: %w", err)
 		siw.ErrorHandlerFunc(w, r, &InvalidParamFormatError{err})
 		return
 	}
@@ -3214,7 +3214,7 @@ func (siw *ServerInterfaceWrapper) GetQueryForm(w http.ResponseWriter, r *http.R
 	}
 
 	if err := runtime.BindQueryParameter("form", true, false, "eo", r.URL.Query(), &params.Eo); err != nil {
-		err = fmt.Errorf("Invalid format for parameter eo: %w", err)
+		err = fmt.Errorf("invalid format for parameter eo: %w", err)
 		siw.ErrorHandlerFunc(w, r, &InvalidParamFormatError{err})
 		return
 	}
@@ -3225,7 +3225,7 @@ func (siw *ServerInterfaceWrapper) GetQueryForm(w http.ResponseWriter, r *http.R
 	}
 
 	if err := runtime.BindQueryParameter("form", false, false, "o", r.URL.Query(), &params.O); err != nil {
-		err = fmt.Errorf("Invalid format for parameter o: %w", err)
+		err = fmt.Errorf("invalid format for parameter o: %w", err)
 		siw.ErrorHandlerFunc(w, r, &InvalidParamFormatError{err})
 		return
 	}
@@ -3236,7 +3236,7 @@ func (siw *ServerInterfaceWrapper) GetQueryForm(w http.ResponseWriter, r *http.R
 	}
 
 	if err := runtime.BindQueryParameter("form", true, false, "ep", r.URL.Query(), &params.Ep); err != nil {
-		err = fmt.Errorf("Invalid format for parameter ep: %w", err)
+		err = fmt.Errorf("invalid format for parameter ep: %w", err)
 		siw.ErrorHandlerFunc(w, r, &InvalidParamFormatError{err})
 		return
 	}
@@ -3247,7 +3247,7 @@ func (siw *ServerInterfaceWrapper) GetQueryForm(w http.ResponseWriter, r *http.R
 	}
 
 	if err := runtime.BindQueryParameter("form", false, false, "p", r.URL.Query(), &params.P); err != nil {
-		err = fmt.Errorf("Invalid format for parameter p: %w", err)
+		err = fmt.Errorf("invalid format for parameter p: %w", err)
 		siw.ErrorHandlerFunc(w, r, &InvalidParamFormatError{err})
 		return
 	}
@@ -3258,7 +3258,7 @@ func (siw *ServerInterfaceWrapper) GetQueryForm(w http.ResponseWriter, r *http.R
 	}
 
 	if err := runtime.BindQueryParameter("form", true, false, "ps", r.URL.Query(), &params.Ps); err != nil {
-		err = fmt.Errorf("Invalid format for parameter ps: %w", err)
+		err = fmt.Errorf("invalid format for parameter ps: %w", err)
 		siw.ErrorHandlerFunc(w, r, &InvalidParamFormatError{err})
 		return
 	}
@@ -3268,7 +3268,7 @@ func (siw *ServerInterfaceWrapper) GetQueryForm(w http.ResponseWriter, r *http.R
 
 		var value ComplexObject
 		if err := json.Unmarshal([]byte(paramValue), &value); err != nil {
-			err = fmt.Errorf("Error unmarshaling parameter 'co' as JSON: %w", err)
+			err = fmt.Errorf("error unmarshaling parameter 'co' as JSON: %w", err)
 			siw.ErrorHandlerFunc(w, r, &UnmarshalingParamError{err})
 			return
 		}
@@ -3283,7 +3283,7 @@ func (siw *ServerInterfaceWrapper) GetQueryForm(w http.ResponseWriter, r *http.R
 	}
 
 	if err := runtime.BindQueryParameter("form", true, false, "1s", r.URL.Query(), &params.N1s); err != nil {
-		err = fmt.Errorf("Invalid format for parameter 1s: %w", err)
+		err = fmt.Errorf("invalid format for parameter 1s: %w", err)
 		siw.ErrorHandlerFunc(w, r, &InvalidParamFormatError{err})
 		return
 	}
@@ -3307,7 +3307,7 @@ func (siw *ServerInterfaceWrapper) GetSimpleExplodeArray(w http.ResponseWriter, 
 	var param []int32
 
 	if err := runtime.BindStyledParameter("simple", true, "param", chi.URLParam(r, "param"), &param); err != nil {
-		err = fmt.Errorf("Invalid format for parameter param: %w", err)
+		err = fmt.Errorf("invalid format for parameter param: %w", err)
 		siw.ErrorHandlerFunc(w, r, &InvalidParamFormatError{err})
 		return
 	}
@@ -3331,7 +3331,7 @@ func (siw *ServerInterfaceWrapper) GetSimpleExplodeObject(w http.ResponseWriter,
 	var param Object
 
 	if err := runtime.BindStyledParameter("simple", true, "param", chi.URLParam(r, "param"), &param); err != nil {
-		err = fmt.Errorf("Invalid format for parameter param: %w", err)
+		err = fmt.Errorf("invalid format for parameter param: %w", err)
 		siw.ErrorHandlerFunc(w, r, &InvalidParamFormatError{err})
 		return
 	}
@@ -3355,7 +3355,7 @@ func (siw *ServerInterfaceWrapper) GetSimpleNoExplodeArray(w http.ResponseWriter
 	var param []int32
 
 	if err := runtime.BindStyledParameter("simple", false, "param", chi.URLParam(r, "param"), &param); err != nil {
-		err = fmt.Errorf("Invalid format for parameter param: %w", err)
+		err = fmt.Errorf("invalid format for parameter param: %w", err)
 		siw.ErrorHandlerFunc(w, r, &InvalidParamFormatError{err})
 		return
 	}
@@ -3379,7 +3379,7 @@ func (siw *ServerInterfaceWrapper) GetSimpleNoExplodeObject(w http.ResponseWrite
 	var param Object
 
 	if err := runtime.BindStyledParameter("simple", false, "param", chi.URLParam(r, "param"), &param); err != nil {
-		err = fmt.Errorf("Invalid format for parameter param: %w", err)
+		err = fmt.Errorf("invalid format for parameter param: %w", err)
 		siw.ErrorHandlerFunc(w, r, &InvalidParamFormatError{err})
 		return
 	}
@@ -3403,7 +3403,7 @@ func (siw *ServerInterfaceWrapper) GetSimplePrimitive(w http.ResponseWriter, r *
 	var param int32
 
 	if err := runtime.BindStyledParameter("simple", false, "param", chi.URLParam(r, "param"), &param); err != nil {
-		err = fmt.Errorf("Invalid format for parameter param: %w", err)
+		err = fmt.Errorf("invalid format for parameter param: %w", err)
 		siw.ErrorHandlerFunc(w, r, &InvalidParamFormatError{err})
 		return
 	}

--- a/internal/test/schemas/schemas.gen.go
+++ b/internal/test/schemas/schemas.gen.go
@@ -26,7 +26,7 @@ import (
 )
 
 const (
-	Access_tokenScopes = "access_token.Scopes"
+	AccessTokenScopes = "access_token.Scopes"
 )
 
 // Defines values for EnumInObjInArrayVal.
@@ -859,7 +859,7 @@ func (c *ClientWithResponses) Issue127WithResponse(ctx context.Context, reqEdito
 	if err != nil {
 		return nil, err
 	}
-	return ParseIssue127Response(rsp)
+	return ParseIssue127response(rsp)
 }
 
 // Issue185WithBodyWithResponse request with arbitrary body returning *Issue185Response
@@ -868,7 +868,7 @@ func (c *ClientWithResponses) Issue185WithBodyWithResponse(ctx context.Context, 
 	if err != nil {
 		return nil, err
 	}
-	return ParseIssue185Response(rsp)
+	return ParseIssue185response(rsp)
 }
 
 func (c *ClientWithResponses) Issue185WithResponse(ctx context.Context, body Issue185JSONRequestBody, reqEditors ...RequestEditorFn) (*Issue185Response, error) {
@@ -876,7 +876,7 @@ func (c *ClientWithResponses) Issue185WithResponse(ctx context.Context, body Iss
 	if err != nil {
 		return nil, err
 	}
-	return ParseIssue185Response(rsp)
+	return ParseIssue185response(rsp)
 }
 
 // Issue209WithResponse request returning *Issue209Response
@@ -885,7 +885,7 @@ func (c *ClientWithResponses) Issue209WithResponse(ctx context.Context, str Stri
 	if err != nil {
 		return nil, err
 	}
-	return ParseIssue209Response(rsp)
+	return ParseIssue209response(rsp)
 }
 
 // Issue30WithResponse request returning *Issue30Response
@@ -894,7 +894,7 @@ func (c *ClientWithResponses) Issue30WithResponse(ctx context.Context, pFallthro
 	if err != nil {
 		return nil, err
 	}
-	return ParseIssue30Response(rsp)
+	return ParseIssue30response(rsp)
 }
 
 // GetIssues375WithResponse request returning *GetIssues375Response
@@ -903,7 +903,7 @@ func (c *ClientWithResponses) GetIssues375WithResponse(ctx context.Context, reqE
 	if err != nil {
 		return nil, err
 	}
-	return ParseGetIssues375Response(rsp)
+	return ParseGetIssues375response(rsp)
 }
 
 // Issue41WithResponse request returning *Issue41Response
@@ -912,7 +912,7 @@ func (c *ClientWithResponses) Issue41WithResponse(ctx context.Context, n1param N
 	if err != nil {
 		return nil, err
 	}
-	return ParseIssue41Response(rsp)
+	return ParseIssue41response(rsp)
 }
 
 // Issue9WithBodyWithResponse request with arbitrary body returning *Issue9Response
@@ -921,7 +921,7 @@ func (c *ClientWithResponses) Issue9WithBodyWithResponse(ctx context.Context, pa
 	if err != nil {
 		return nil, err
 	}
-	return ParseIssue9Response(rsp)
+	return ParseIssue9response(rsp)
 }
 
 func (c *ClientWithResponses) Issue9WithResponse(ctx context.Context, params *Issue9Params, body Issue9JSONRequestBody, reqEditors ...RequestEditorFn) (*Issue9Response, error) {
@@ -929,7 +929,7 @@ func (c *ClientWithResponses) Issue9WithResponse(ctx context.Context, params *Is
 	if err != nil {
 		return nil, err
 	}
-	return ParseIssue9Response(rsp)
+	return ParseIssue9response(rsp)
 }
 
 // ParseEnsureEverythingIsReferencedResponse parses an HTTP response from a EnsureEverythingIsReferencedWithResponse call
@@ -966,8 +966,8 @@ func ParseEnsureEverythingIsReferencedResponse(rsp *http.Response) (*EnsureEvery
 	return response, nil
 }
 
-// ParseIssue127Response parses an HTTP response from a Issue127WithResponse call
-func ParseIssue127Response(rsp *http.Response) (*Issue127Response, error) {
+// ParseIssue127response parses an HTTP response from a Issue127WithResponse call
+func ParseIssue127response(rsp *http.Response) (*Issue127Response, error) {
 	bodyBytes, err := ioutil.ReadAll(rsp.Body)
 	defer func() { _ = rsp.Body.Close() }()
 	if err != nil {
@@ -1019,8 +1019,8 @@ func ParseIssue127Response(rsp *http.Response) (*Issue127Response, error) {
 	return response, nil
 }
 
-// ParseIssue185Response parses an HTTP response from a Issue185WithResponse call
-func ParseIssue185Response(rsp *http.Response) (*Issue185Response, error) {
+// ParseIssue185response parses an HTTP response from a Issue185WithResponse call
+func ParseIssue185response(rsp *http.Response) (*Issue185Response, error) {
 	bodyBytes, err := ioutil.ReadAll(rsp.Body)
 	defer func() { _ = rsp.Body.Close() }()
 	if err != nil {
@@ -1035,8 +1035,8 @@ func ParseIssue185Response(rsp *http.Response) (*Issue185Response, error) {
 	return response, nil
 }
 
-// ParseIssue209Response parses an HTTP response from a Issue209WithResponse call
-func ParseIssue209Response(rsp *http.Response) (*Issue209Response, error) {
+// ParseIssue209response parses an HTTP response from a Issue209WithResponse call
+func ParseIssue209response(rsp *http.Response) (*Issue209Response, error) {
 	bodyBytes, err := ioutil.ReadAll(rsp.Body)
 	defer func() { _ = rsp.Body.Close() }()
 	if err != nil {
@@ -1051,8 +1051,8 @@ func ParseIssue209Response(rsp *http.Response) (*Issue209Response, error) {
 	return response, nil
 }
 
-// ParseIssue30Response parses an HTTP response from a Issue30WithResponse call
-func ParseIssue30Response(rsp *http.Response) (*Issue30Response, error) {
+// ParseIssue30response parses an HTTP response from a Issue30WithResponse call
+func ParseIssue30response(rsp *http.Response) (*Issue30Response, error) {
 	bodyBytes, err := ioutil.ReadAll(rsp.Body)
 	defer func() { _ = rsp.Body.Close() }()
 	if err != nil {
@@ -1067,8 +1067,8 @@ func ParseIssue30Response(rsp *http.Response) (*Issue30Response, error) {
 	return response, nil
 }
 
-// ParseGetIssues375Response parses an HTTP response from a GetIssues375WithResponse call
-func ParseGetIssues375Response(rsp *http.Response) (*GetIssues375Response, error) {
+// ParseGetIssues375response parses an HTTP response from a GetIssues375WithResponse call
+func ParseGetIssues375response(rsp *http.Response) (*GetIssues375Response, error) {
 	bodyBytes, err := ioutil.ReadAll(rsp.Body)
 	defer func() { _ = rsp.Body.Close() }()
 	if err != nil {
@@ -1093,8 +1093,8 @@ func ParseGetIssues375Response(rsp *http.Response) (*GetIssues375Response, error
 	return response, nil
 }
 
-// ParseIssue41Response parses an HTTP response from a Issue41WithResponse call
-func ParseIssue41Response(rsp *http.Response) (*Issue41Response, error) {
+// ParseIssue41response parses an HTTP response from a Issue41WithResponse call
+func ParseIssue41response(rsp *http.Response) (*Issue41Response, error) {
 	bodyBytes, err := ioutil.ReadAll(rsp.Body)
 	defer func() { _ = rsp.Body.Close() }()
 	if err != nil {
@@ -1109,8 +1109,8 @@ func ParseIssue41Response(rsp *http.Response) (*Issue41Response, error) {
 	return response, nil
 }
 
-// ParseIssue9Response parses an HTTP response from a Issue9WithResponse call
-func ParseIssue9Response(rsp *http.Response) (*Issue9Response, error) {
+// ParseIssue9response parses an HTTP response from a Issue9WithResponse call
+func ParseIssue9response(rsp *http.Response) (*Issue9Response, error) {
 	bodyBytes, err := ioutil.ReadAll(rsp.Body)
 	defer func() { _ = rsp.Body.Close() }()
 	if err != nil {
@@ -1167,7 +1167,7 @@ type MiddlewareFunc func(http.Handler) http.Handler
 func (siw *ServerInterfaceWrapper) EnsureEverythingIsReferenced(w http.ResponseWriter, r *http.Request) {
 	ctx := r.Context()
 
-	ctx = context.WithValue(ctx, Access-tokenScopes, []string{""})
+	ctx = context.WithValue(ctx, AccessTokenScopes, []string{""})
 
 	var handler = http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		siw.Handler.EnsureEverythingIsReferenced(w, r)
@@ -1184,7 +1184,7 @@ func (siw *ServerInterfaceWrapper) EnsureEverythingIsReferenced(w http.ResponseW
 func (siw *ServerInterfaceWrapper) Issue127(w http.ResponseWriter, r *http.Request) {
 	ctx := r.Context()
 
-	ctx = context.WithValue(ctx, Access-tokenScopes, []string{""})
+	ctx = context.WithValue(ctx, AccessTokenScopes, []string{""})
 
 	var handler = http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		siw.Handler.Issue127(w, r)
@@ -1201,7 +1201,7 @@ func (siw *ServerInterfaceWrapper) Issue127(w http.ResponseWriter, r *http.Reque
 func (siw *ServerInterfaceWrapper) Issue185(w http.ResponseWriter, r *http.Request) {
 	ctx := r.Context()
 
-	ctx = context.WithValue(ctx, Access-tokenScopes, []string{""})
+	ctx = context.WithValue(ctx, AccessTokenScopes, []string{""})
 
 	var handler = http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		siw.Handler.Issue185(w, r)
@@ -1222,12 +1222,12 @@ func (siw *ServerInterfaceWrapper) Issue209(w http.ResponseWriter, r *http.Reque
 	var str StringInPath
 
 	if err := runtime.BindStyledParameter("simple", false, "str", chi.URLParam(r, "str"), &str); err != nil {
-		err = fmt.Errorf("Invalid format for parameter str: %w", err)
+		err = fmt.Errorf("invalid format for parameter str: %w", err)
 		siw.ErrorHandlerFunc(w, r, &InvalidParamFormatError{err})
 		return
 	}
 
-	ctx = context.WithValue(ctx, Access-tokenScopes, []string{""})
+	ctx = context.WithValue(ctx, AccessTokenScopes, []string{""})
 
 	var handler = http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		siw.Handler.Issue209(w, r, str)
@@ -1248,12 +1248,12 @@ func (siw *ServerInterfaceWrapper) Issue30(w http.ResponseWriter, r *http.Reques
 	var pFallthrough string
 
 	if err := runtime.BindStyledParameter("simple", false, "fallthrough", chi.URLParam(r, "fallthrough"), &pFallthrough); err != nil {
-		err = fmt.Errorf("Invalid format for parameter fallthrough: %w", err)
+		err = fmt.Errorf("invalid format for parameter fallthrough: %w", err)
 		siw.ErrorHandlerFunc(w, r, &InvalidParamFormatError{err})
 		return
 	}
 
-	ctx = context.WithValue(ctx, Access-tokenScopes, []string{""})
+	ctx = context.WithValue(ctx, AccessTokenScopes, []string{""})
 
 	var handler = http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		siw.Handler.Issue30(w, r, pFallthrough)
@@ -1270,7 +1270,7 @@ func (siw *ServerInterfaceWrapper) Issue30(w http.ResponseWriter, r *http.Reques
 func (siw *ServerInterfaceWrapper) GetIssues375(w http.ResponseWriter, r *http.Request) {
 	ctx := r.Context()
 
-	ctx = context.WithValue(ctx, Access-tokenScopes, []string{""})
+	ctx = context.WithValue(ctx, AccessTokenScopes, []string{""})
 
 	var handler = http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		siw.Handler.GetIssues375(w, r)
@@ -1291,12 +1291,12 @@ func (siw *ServerInterfaceWrapper) Issue41(w http.ResponseWriter, r *http.Reques
 	var n1param N5startsWithNumber
 
 	if err := runtime.BindStyledParameter("simple", false, "1param", chi.URLParam(r, "1param"), &n1param); err != nil {
-		err = fmt.Errorf("Invalid format for parameter 1param: %w", err)
+		err = fmt.Errorf("invalid format for parameter 1param: %w", err)
 		siw.ErrorHandlerFunc(w, r, &InvalidParamFormatError{err})
 		return
 	}
 
-	ctx = context.WithValue(ctx, Access-tokenScopes, []string{""})
+	ctx = context.WithValue(ctx, AccessTokenScopes, []string{""})
 
 	var handler = http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		siw.Handler.Issue41(w, r, n1param)
@@ -1313,7 +1313,7 @@ func (siw *ServerInterfaceWrapper) Issue41(w http.ResponseWriter, r *http.Reques
 func (siw *ServerInterfaceWrapper) Issue9(w http.ResponseWriter, r *http.Request) {
 	ctx := r.Context()
 
-	ctx = context.WithValue(ctx, Access-tokenScopes, []string{""})
+	ctx = context.WithValue(ctx, AccessTokenScopes, []string{""})
 
 	// Parameter object where we will unmarshal all parameters from the context
 	var params Issue9Params
@@ -1322,13 +1322,13 @@ func (siw *ServerInterfaceWrapper) Issue9(w http.ResponseWriter, r *http.Request
 	if paramValue := r.URL.Query().Get("foo"); paramValue != "" {
 
 	} else {
-		err := fmt.Errorf("Query argument foo is required, but not found")
+		err := fmt.Errorf("query argument foo is required, but not found")
 		siw.ErrorHandlerFunc(w, r, &RequiredParamError{err})
 		return
 	}
 
 	if err := runtime.BindQueryParameter("form", true, true, "foo", r.URL.Query(), &params.Foo); err != nil {
-		err = fmt.Errorf("Invalid format for parameter foo: %w", err)
+		err = fmt.Errorf("invalid format for parameter foo: %w", err)
 		siw.ErrorHandlerFunc(w, r, &InvalidParamFormatError{err})
 		return
 	}

--- a/internal/test/server/server.gen.go
+++ b/internal/test/server/server.gen.go
@@ -221,7 +221,7 @@ func (siw *ServerInterfaceWrapper) GetWithArgs(w http.ResponseWriter, r *http.Re
 	}
 
 	if err := runtime.BindQueryParameter("form", true, false, "optional_argument", r.URL.Query(), &params.OptionalArgument); err != nil {
-		err = fmt.Errorf("Invalid format for parameter optional_argument: %w", err)
+		err = fmt.Errorf("invalid format for parameter optional_argument: %w", err)
 		siw.ErrorHandlerFunc(w, r, &InvalidParamFormatError{err})
 		return
 	}
@@ -230,13 +230,13 @@ func (siw *ServerInterfaceWrapper) GetWithArgs(w http.ResponseWriter, r *http.Re
 	if paramValue := r.URL.Query().Get("required_argument"); paramValue != "" {
 
 	} else {
-		err := fmt.Errorf("Query argument required_argument is required, but not found")
+		err := fmt.Errorf("query argument required_argument is required, but not found")
 		siw.ErrorHandlerFunc(w, r, &RequiredParamError{err})
 		return
 	}
 
 	if err := runtime.BindQueryParameter("form", true, true, "required_argument", r.URL.Query(), &params.RequiredArgument); err != nil {
-		err = fmt.Errorf("Invalid format for parameter required_argument: %w", err)
+		err = fmt.Errorf("invalid format for parameter required_argument: %w", err)
 		siw.ErrorHandlerFunc(w, r, &InvalidParamFormatError{err})
 		return
 	}
@@ -248,13 +248,13 @@ func (siw *ServerInterfaceWrapper) GetWithArgs(w http.ResponseWriter, r *http.Re
 		var HeaderArgument int32
 		n := len(valueList)
 		if n != 1 {
-			err := fmt.Errorf("Expected one value for header_argument, got %d", n)
+			err := fmt.Errorf("expected one value for header_argument, got %d", n)
 			siw.ErrorHandlerFunc(w, r, &TooManyValuesForParamError{err})
 			return
 		}
 
 		if err := runtime.BindStyledParameterWithLocation("simple", false, "header_argument", runtime.ParamLocationHeader, valueList[0], &HeaderArgument); err != nil {
-			err = fmt.Errorf("Invalid format for parameter header_argument: %w", err)
+			err = fmt.Errorf("invalid format for parameter header_argument: %w", err)
 			siw.ErrorHandlerFunc(w, r, &InvalidParamFormatError{err})
 			return
 		}
@@ -282,7 +282,7 @@ func (siw *ServerInterfaceWrapper) GetWithReferences(w http.ResponseWriter, r *h
 	var globalArgument int64
 
 	if err := runtime.BindStyledParameter("simple", false, "global_argument", chi.URLParam(r, "global_argument"), &globalArgument); err != nil {
-		err = fmt.Errorf("Invalid format for parameter global_argument: %w", err)
+		err = fmt.Errorf("invalid format for parameter global_argument: %w", err)
 		siw.ErrorHandlerFunc(w, r, &InvalidParamFormatError{err})
 		return
 	}
@@ -291,7 +291,7 @@ func (siw *ServerInterfaceWrapper) GetWithReferences(w http.ResponseWriter, r *h
 	var argument Argument
 
 	if err := runtime.BindStyledParameter("simple", false, "argument", chi.URLParam(r, "argument"), &argument); err != nil {
-		err = fmt.Errorf("Invalid format for parameter argument: %w", err)
+		err = fmt.Errorf("invalid format for parameter argument: %w", err)
 		siw.ErrorHandlerFunc(w, r, &InvalidParamFormatError{err})
 		return
 	}
@@ -362,7 +362,7 @@ func (siw *ServerInterfaceWrapper) GetWithContentType(w http.ResponseWriter, r *
 	var contentType GetWithContentTypeParamsContentType
 
 	if err := runtime.BindStyledParameter("simple", false, "content_type", chi.URLParam(r, "content_type"), &contentType); err != nil {
-		err = fmt.Errorf("Invalid format for parameter content_type: %w", err)
+		err = fmt.Errorf("invalid format for parameter content_type: %w", err)
 		siw.ErrorHandlerFunc(w, r, &InvalidParamFormatError{err})
 		return
 	}
@@ -401,7 +401,7 @@ func (siw *ServerInterfaceWrapper) CreateResource(w http.ResponseWriter, r *http
 	var argument Argument
 
 	if err := runtime.BindStyledParameter("simple", false, "argument", chi.URLParam(r, "argument"), &argument); err != nil {
-		err = fmt.Errorf("Invalid format for parameter argument: %w", err)
+		err = fmt.Errorf("invalid format for parameter argument: %w", err)
 		siw.ErrorHandlerFunc(w, r, &InvalidParamFormatError{err})
 		return
 	}
@@ -425,7 +425,7 @@ func (siw *ServerInterfaceWrapper) CreateResource2(w http.ResponseWriter, r *htt
 	var inlineArgument int
 
 	if err := runtime.BindStyledParameter("simple", false, "inline_argument", chi.URLParam(r, "inline_argument"), &inlineArgument); err != nil {
-		err = fmt.Errorf("Invalid format for parameter inline_argument: %w", err)
+		err = fmt.Errorf("invalid format for parameter inline_argument: %w", err)
 		siw.ErrorHandlerFunc(w, r, &InvalidParamFormatError{err})
 		return
 	}
@@ -439,7 +439,7 @@ func (siw *ServerInterfaceWrapper) CreateResource2(w http.ResponseWriter, r *htt
 	}
 
 	if err := runtime.BindQueryParameter("form", true, false, "inline_query_argument", r.URL.Query(), &params.InlineQueryArgument); err != nil {
-		err = fmt.Errorf("Invalid format for parameter inline_query_argument: %w", err)
+		err = fmt.Errorf("invalid format for parameter inline_query_argument: %w", err)
 		siw.ErrorHandlerFunc(w, r, &InvalidParamFormatError{err})
 		return
 	}
@@ -463,7 +463,7 @@ func (siw *ServerInterfaceWrapper) UpdateResource3(w http.ResponseWriter, r *htt
 	var pFallthrough int
 
 	if err := runtime.BindStyledParameter("simple", false, "fallthrough", chi.URLParam(r, "fallthrough"), &pFallthrough); err != nil {
-		err = fmt.Errorf("Invalid format for parameter fallthrough: %w", err)
+		err = fmt.Errorf("invalid format for parameter fallthrough: %w", err)
 		siw.ErrorHandlerFunc(w, r, &InvalidParamFormatError{err})
 		return
 	}

--- a/internal/test/server/server_test.go
+++ b/internal/test/server/server_test.go
@@ -58,5 +58,5 @@ func TestErrorHandlerFuncBackwardsCompatible(t *testing.T) {
 	b, _ := ioutil.ReadAll(req.Body)
 	assert.Nil(t, err)
 	assert.Equal(t, "text/plain; charset=utf-8", req.Header.Get("Content-Type"))
-	assert.Equal(t, "Query argument required_argument is required, but not found\n", string(b))
+	assert.Equal(t, "query argument required_argument is required, but not found\n", string(b))
 }

--- a/pkg/codegen/operations.go
+++ b/pkg/codegen/operations.go
@@ -17,10 +17,11 @@ import (
 	"bufio"
 	"bytes"
 	"fmt"
-	"github.com/kenshaw/snaker"
 	"strings"
 	"text/template"
 	"unicode"
+
+	"github.com/kenshaw/snaker"
 
 	"github.com/getkin/kin-openapi/openapi3"
 )
@@ -277,7 +278,7 @@ func (o *OperationDefinition) GetResponseTypeDefinitions() ([]ResponseTypeDefini
 				if contentType.Schema != nil {
 					responseSchema, err := GenerateGoSchema(contentType.Schema, []string{responseName})
 					if err != nil {
-						return nil, fmt.Errorf("Unable to determine Go type for %s.%s: %w", o.OperationId, contentTypeName, err)
+						return nil, fmt.Errorf("unable to determine Go type for %s.%s: %w", o.OperationId, contentTypeName, err)
 					}
 
 					var typeName string

--- a/pkg/codegen/operations_test.go
+++ b/pkg/codegen/operations_test.go
@@ -16,6 +16,8 @@ package codegen
 import (
 	"net/http"
 	"testing"
+
+	"github.com/getkin/kin-openapi/openapi3"
 )
 
 func TestGenerateDefaultOperationID(t *testing.T) {
@@ -77,5 +79,77 @@ func TestGenerateDefaultOperationID(t *testing.T) {
 		if got != test.want {
 			t.Fatalf("Operation ID generation error. Want [%v] Got [%v]", test.want, got)
 		}
+	}
+}
+
+func TestParameterDefinition_GoVariableName(t *testing.T) {
+	type fields struct {
+		ParamName string
+		In        string
+		Required  bool
+		Spec      *openapi3.Parameter
+		Schema    Schema
+	}
+	tests := []struct {
+		name   string
+		fields fields
+		want   string
+	}{
+		{
+			name: "simple",
+			fields: fields{
+				ParamName: "foo",
+			},
+			want: "foo",
+		},
+		{
+			name: "starts with number",
+			fields: fields{
+				ParamName: "1foo",
+			},
+			want: "n1foo",
+		},
+		{
+			name: "contains underscode",
+			fields: fields{
+				ParamName: "foo_bar",
+			},
+			want: "fooBar",
+		},
+		{
+			name: "contains dash",
+			fields: fields{
+				ParamName: "foo-bar",
+			},
+			want: "fooBar",
+		},
+		{
+			name: "contains dash and underscore",
+			fields: fields{
+				ParamName: "foo-bar_baz",
+			},
+			want: "fooBarBaz",
+		},
+		{
+			name: "contains URI",
+			fields: fields{
+				ParamName: "foo-bar_baz_uri",
+			},
+			want: "fooBarBazURI",
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			pd := ParameterDefinition{
+				ParamName: tt.fields.ParamName,
+				In:        tt.fields.In,
+				Required:  tt.fields.Required,
+				Spec:      tt.fields.Spec,
+				Schema:    tt.fields.Schema,
+			}
+			if got := pd.GoVariableName(); got != tt.want {
+				t.Errorf("ParameterDefinition.GoVariableName() = %v, want %v", got, tt.want)
+			}
+		})
 	}
 }

--- a/pkg/codegen/prune.go
+++ b/pkg/codegen/prune.go
@@ -394,7 +394,7 @@ func findComponentRefs(swagger *openapi3.T) []string {
 func removeOrphanedComponents(swagger *openapi3.T, refs []string) int {
 	countRemoved := 0
 
-	for key, _ := range swagger.Components.Schemas {
+	for key := range swagger.Components.Schemas {
 		ref := fmt.Sprintf("#/components/schemas/%s", key)
 		if !stringInSlice(ref, refs) {
 			countRemoved++
@@ -402,7 +402,7 @@ func removeOrphanedComponents(swagger *openapi3.T, refs []string) int {
 		}
 	}
 
-	for key, _ := range swagger.Components.Parameters {
+	for key := range swagger.Components.Parameters {
 		ref := fmt.Sprintf("#/components/parameters/%s", key)
 		if !stringInSlice(ref, refs) {
 			countRemoved++
@@ -421,7 +421,7 @@ func removeOrphanedComponents(swagger *openapi3.T, refs []string) int {
 	// 	}
 	// }
 
-	for key, _ := range swagger.Components.RequestBodies {
+	for key := range swagger.Components.RequestBodies {
 		ref := fmt.Sprintf("#/components/requestBodies/%s", key)
 		if !stringInSlice(ref, refs) {
 			countRemoved++
@@ -429,7 +429,7 @@ func removeOrphanedComponents(swagger *openapi3.T, refs []string) int {
 		}
 	}
 
-	for key, _ := range swagger.Components.Responses {
+	for key := range swagger.Components.Responses {
 		ref := fmt.Sprintf("#/components/responses/%s", key)
 		if !stringInSlice(ref, refs) {
 			countRemoved++
@@ -437,7 +437,7 @@ func removeOrphanedComponents(swagger *openapi3.T, refs []string) int {
 		}
 	}
 
-	for key, _ := range swagger.Components.Headers {
+	for key := range swagger.Components.Headers {
 		ref := fmt.Sprintf("#/components/headers/%s", key)
 		if !stringInSlice(ref, refs) {
 			countRemoved++
@@ -445,7 +445,7 @@ func removeOrphanedComponents(swagger *openapi3.T, refs []string) int {
 		}
 	}
 
-	for key, _ := range swagger.Components.Examples {
+	for key := range swagger.Components.Examples {
 		ref := fmt.Sprintf("#/components/examples/%s", key)
 		if !stringInSlice(ref, refs) {
 			countRemoved++
@@ -453,7 +453,7 @@ func removeOrphanedComponents(swagger *openapi3.T, refs []string) int {
 		}
 	}
 
-	for key, _ := range swagger.Components.Links {
+	for key := range swagger.Components.Links {
 		ref := fmt.Sprintf("#/components/links/%s", key)
 		if !stringInSlice(ref, refs) {
 			countRemoved++
@@ -461,7 +461,7 @@ func removeOrphanedComponents(swagger *openapi3.T, refs []string) int {
 		}
 	}
 
-	for key, _ := range swagger.Components.Callbacks {
+	for key := range swagger.Components.Callbacks {
 		ref := fmt.Sprintf("#/components/callbacks/%s", key)
 		if !stringInSlice(ref, refs) {
 			countRemoved++

--- a/pkg/codegen/schema.go
+++ b/pkg/codegen/schema.go
@@ -45,7 +45,7 @@ func (s *Schema) MergeProperty(p Property) error {
 	// Scan all existing properties for a conflict
 	for _, e := range s.Properties {
 		if e.JsonFieldName == p.JsonFieldName && !PropertiesEqual(e, p) {
-			return errors.New(fmt.Sprintf("property '%s' already exists with a different type", e.JsonFieldName))
+			return fmt.Errorf("property '%s' already exists with a different type", e.JsonFieldName)
 		}
 	}
 	s.Properties = append(s.Properties, p)
@@ -339,38 +339,40 @@ func resolveType(schema *openapi3.Schema, path []string, outSchema *Schema) erro
 		outSchema.Properties = arrayType.Properties
 	case "integer":
 		// We default to int if format doesn't ask for something else.
-		if f == "int64" {
+		switch f {
+		case "int64":
 			outSchema.GoType = "int64"
-		} else if f == "int32" {
+		case "int32":
 			outSchema.GoType = "int32"
-		} else if f == "int16" {
+		case "int16":
 			outSchema.GoType = "int16"
-		} else if f == "int8" {
+		case "int8":
 			outSchema.GoType = "int8"
-		} else if f == "int" {
+		case "int":
 			outSchema.GoType = "int"
-		} else if f == "uint64" {
+		case "uint64":
 			outSchema.GoType = "uint64"
-		} else if f == "uint32" {
+		case "uint32":
 			outSchema.GoType = "uint32"
-		} else if f == "uint16" {
+		case "uint16":
 			outSchema.GoType = "uint16"
-		} else if f == "uint8" {
+		case "uint8":
 			outSchema.GoType = "uint8"
-		} else if f == "uint" {
+		case "uint":
 			outSchema.GoType = "uint"
-		} else if f == "" {
+		case "":
 			outSchema.GoType = "int"
-		} else {
+		default:
 			return fmt.Errorf("invalid integer format: %s", f)
 		}
 	case "number":
 		// We default to float for "number"
-		if f == "double" {
+		switch f {
+		case "double":
 			outSchema.GoType = "float64"
-		} else if f == "float" || f == "" {
+		case "float", "":
 			outSchema.GoType = "float32"
-		} else {
+		default:
 			return fmt.Errorf("invalid number format: %s", f)
 		}
 	case "boolean":

--- a/pkg/codegen/template_helpers.go
+++ b/pkg/codegen/template_helpers.go
@@ -19,6 +19,8 @@ import (
 	"os"
 	"strings"
 	"text/template"
+
+	"github.com/kenshaw/snaker"
 )
 
 const (
@@ -80,7 +82,7 @@ func genParamNames(params []ParameterDefinition) string {
 
 // genResponsePayload generates the payload returned at the end of each client request function
 func genResponsePayload(operationID string) string {
-	var buffer = bytes.NewBufferString("")
+	buffer := bytes.NewBufferString("")
 
 	// Here is where we build up a response:
 	fmt.Fprintf(buffer, "&%s{\n", genResponseTypeName(operationID))
@@ -93,8 +95,8 @@ func genResponsePayload(operationID string) string {
 
 // genResponseUnmarshal generates unmarshaling steps for structured response payloads
 func genResponseUnmarshal(op *OperationDefinition) string {
-	var handledCaseClauses = make(map[string]string)
-	var unhandledCaseClauses = make(map[string]string)
+	handledCaseClauses := make(map[string]string)
+	unhandledCaseClauses := make(map[string]string)
 
 	// Get the type definitions from the operation:
 	typeDefinitions, err := op.GetResponseTypeDefinitions()
@@ -147,9 +149,7 @@ func genResponseUnmarshal(op *OperationDefinition) string {
 			// JSON:
 			case StringInArray(contentTypeName, contentTypesJSON):
 				if typeDefinition.ContentTypeName == contentTypeName {
-					var caseAction string
-
-					caseAction = fmt.Sprintf("var dest %s\n"+
+					caseAction := fmt.Sprintf("var dest %s\n"+
 						"if err := json.Unmarshal(bodyBytes, &dest); err != nil { \n"+
 						" return nil, err \n"+
 						"}\n"+
@@ -164,8 +164,7 @@ func genResponseUnmarshal(op *OperationDefinition) string {
 			// YAML:
 			case StringInArray(contentTypeName, contentTypesYAML):
 				if typeDefinition.ContentTypeName == contentTypeName {
-					var caseAction string
-					caseAction = fmt.Sprintf("var dest %s\n"+
+					caseAction := fmt.Sprintf("var dest %s\n"+
 						"if err := yaml.Unmarshal(bodyBytes, &dest); err != nil { \n"+
 						" return nil, err \n"+
 						"}\n"+
@@ -179,8 +178,7 @@ func genResponseUnmarshal(op *OperationDefinition) string {
 			// XML:
 			case StringInArray(contentTypeName, contentTypesXML):
 				if typeDefinition.ContentTypeName == contentTypeName {
-					var caseAction string
-					caseAction = fmt.Sprintf("var dest %s\n"+
+					caseAction := fmt.Sprintf("var dest %s\n"+
 						"if err := xml.Unmarshal(bodyBytes, &dest); err != nil { \n"+
 						" return nil, err \n"+
 						"}\n"+
@@ -210,11 +208,9 @@ func genResponseUnmarshal(op *OperationDefinition) string {
 	// groups.
 	fmt.Fprintf(buffer, "switch {\n")
 	for _, caseClauseKey := range SortedStringKeys(handledCaseClauses) {
-
 		fmt.Fprintf(buffer, "%s\n", handledCaseClauses[caseClauseKey])
 	}
 	for _, caseClauseKey := range SortedStringKeys(unhandledCaseClauses) {
-
 		fmt.Fprintf(buffer, "%s\n", unhandledCaseClauses[caseClauseKey])
 	}
 	fmt.Fprintf(buffer, "}\n")
@@ -273,9 +269,9 @@ var TemplateFunctions = template.FuncMap{
 	"genParamNames":              genParamNames,
 	"genParamFmtString":          ReplacePathParamsWithStr,
 	"swaggerUriToChiUri":         SwaggerUriToChiUri,
-	"lcFirst":                    LowercaseFirstCharacter,
-	"ucFirst":                    UppercaseFirstCharacter,
-	"camelCase":                  ToCamelCase,
+	"lcFirst":                    snaker.ForceLowerCamelIdentifier,
+	"ucFirst":                    snaker.ForceCamelIdentifier,
+	"camelCase":                  snaker.SnakeToCamel,
 	"genResponsePayload":         genResponsePayload,
 	"genResponseTypeName":        genResponseTypeName,
 	"genResponseUnmarshal":       genResponseUnmarshal,

--- a/pkg/codegen/templates/chi/chi-middleware.tmpl
+++ b/pkg/codegen/templates/chi/chi-middleware.tmpl
@@ -22,14 +22,14 @@ func (siw *ServerInterfaceWrapper) {{$opid}}(w http.ResponseWriter, r *http.Requ
   {{end}}
   {{if .IsJson}}
   if err := json.Unmarshal([]byte(chi.URLParam(r, "{{.ParamName}}")), &{{$varName}}); err != nil {
-    err = fmt.Errorf("Error unmarshaling parameter '{{.ParamName}}' as JSON: %w", err)
+    err = fmt.Errorf("error unmarshaling parameter '{{.ParamName}}' as JSON: %w", err)
     siw.ErrorHandlerFunc(w, r, &UnmarshalingParamError{err})
     return
   }
   {{end}}
   {{if .IsStyled}}
   if err := runtime.BindStyledParameter("{{.Style}}",{{.Explode}}, "{{.ParamName}}", chi.URLParam(r, "{{.ParamName}}"), &{{$varName}}); err != nil {
-    err = fmt.Errorf("Invalid format for parameter {{.ParamName}}: %w", err)
+    err = fmt.Errorf("invalid format for parameter {{.ParamName}}: %w", err)
     siw.ErrorHandlerFunc(w, r, &InvalidParamFormatError{err})
     return
   }
@@ -55,7 +55,7 @@ func (siw *ServerInterfaceWrapper) {{$opid}}(w http.ResponseWriter, r *http.Requ
       {{if .IsJson}}
         var value {{.TypeDef}}
         if err := json.Unmarshal([]byte(paramValue), &value); err != nil {
-          err = fmt.Errorf("Error unmarshaling parameter '{{.ParamName}}' as JSON: %w", err)
+          err = fmt.Errorf("error unmarshaling parameter '{{.ParamName}}' as JSON: %w", err)
           siw.ErrorHandlerFunc(w, r, &UnmarshalingParamError{err})
           return
         }
@@ -63,13 +63,13 @@ func (siw *ServerInterfaceWrapper) {{$opid}}(w http.ResponseWriter, r *http.Requ
         params.{{.GoName}} = {{if not .Required}}&{{end}}value
       {{end}}
       }{{if .Required}} else {
-          err := fmt.Errorf("Query argument {{.ParamName}} is required, but not found")
+          err := fmt.Errorf("query argument {{.ParamName}} is required, but not found")
           siw.ErrorHandlerFunc(w, r, &RequiredParamError{err})
           return
       }{{end}}
       {{if .IsStyled}}
       if err := runtime.BindQueryParameter("{{.Style}}", {{.Explode}}, {{.Required}}, "{{.ParamName}}", r.URL.Query(), &params.{{.GoName}}); err != nil {
-        err = fmt.Errorf("Invalid format for parameter {{.ParamName}}: %w", err)
+        err = fmt.Errorf("invalid format for parameter {{.ParamName}}: %w", err)
         siw.ErrorHandlerFunc(w, r, &InvalidParamFormatError{err})
         return
       }
@@ -84,7 +84,7 @@ func (siw *ServerInterfaceWrapper) {{$opid}}(w http.ResponseWriter, r *http.Requ
           var {{.GoName}} {{.TypeDef}}
           n := len(valueList)
           if n != 1 {
-            err := fmt.Errorf("Expected one value for {{.ParamName}}, got %d", n)
+            err := fmt.Errorf("expected one value for {{.ParamName}}, got %d", n)
             siw.ErrorHandlerFunc(w, r, &TooManyValuesForParamError{err})
             return
           }
@@ -95,7 +95,7 @@ func (siw *ServerInterfaceWrapper) {{$opid}}(w http.ResponseWriter, r *http.Requ
 
         {{if .IsJson}}
           if err := json.Unmarshal([]byte(valueList[0]), &{{.GoName}}); err != nil {
-            err = fmt.Errorf("Error unmarshaling parameter '{{.ParamName}}' as JSON: %w", err)
+            err = fmt.Errorf("error unmarshaling parameter '{{.ParamName}}' as JSON: %w", err)
             siw.ErrorHandlerFunc(w, r, &UnmarshalingParamError{err})
             return
           }
@@ -103,7 +103,7 @@ func (siw *ServerInterfaceWrapper) {{$opid}}(w http.ResponseWriter, r *http.Requ
 
         {{if .IsStyled}}
           if err := runtime.BindStyledParameterWithLocation("{{.Style}}",{{.Explode}}, "{{.ParamName}}", runtime.ParamLocationHeader, valueList[0], &{{.GoName}}); err != nil {
-            err = fmt.Errorf("Invalid format for parameter {{.ParamName}}: %w", err)
+            err = fmt.Errorf("invalid format for parameter {{.ParamName}}: %w", err)
             siw.ErrorHandlerFunc(w, r, &InvalidParamFormatError{err})
             return
           }
@@ -112,7 +112,7 @@ func (siw *ServerInterfaceWrapper) {{$opid}}(w http.ResponseWriter, r *http.Requ
           params.{{.GoName}} = {{if not .Required}}&{{end}}{{.GoName}}
 
         } {{if .Required}}else {
-            err := fmt.Errorf("Header parameter {{.ParamName}} is required, but not found")
+            err := fmt.Errorf("header parameter {{.ParamName}} is required, but not found")
             siw.ErrorHandlerFunc(w, r, &RequiredHeaderError{err})
             return
         }{{end}}
@@ -132,14 +132,14 @@ func (siw *ServerInterfaceWrapper) {{$opid}}(w http.ResponseWriter, r *http.Requ
         var decoded string
         decoded, err := url.QueryUnescape(cookie.Value)
         if err != nil {
-          err = fmt.Errorf("Error unescaping cookie parameter '{{.ParamName}}'")
+          err = fmt.Errorf("error unescaping cookie parameter '{{.ParamName}}'")
           siw.ErrorHandlerFunc(w, r, &UnescapedCookieParamError{err})
           return
         }
 
         err = json.Unmarshal([]byte(decoded), &value)
         if err != nil {
-          err = fmt.Errorf("Error unmarshaling parameter '{{.ParamName}}' as JSON: %w", err)
+          err = fmt.Errorf("error unmarshaling parameter '{{.ParamName}}' as JSON: %w", err)
           siw.ErrorHandlerFunc(w, r, &UnmarshalingParamError{err})
           return
         }
@@ -150,7 +150,7 @@ func (siw *ServerInterfaceWrapper) {{$opid}}(w http.ResponseWriter, r *http.Requ
       {{- if .IsStyled}}
         var value {{.TypeDef}}
         if err := runtime.BindStyledParameter("simple",{{.Explode}}, "{{.ParamName}}", cookie.Value, &value); err != nil {
-          err = fmt.Errorf("Invalid format for parameter {{.ParamName}}: %w", err)
+          err = fmt.Errorf("invalid format for parameter {{.ParamName}}: %w", err)
           siw.ErrorHandlerFunc(w, r, &InvalidParamFormatError{err})
           return
         }
@@ -160,7 +160,7 @@ func (siw *ServerInterfaceWrapper) {{$opid}}(w http.ResponseWriter, r *http.Requ
       }
 
       {{- if .Required}} else {
-        err := fmt.Errorf("Query argument {{.ParamName}} is required, but not found")
+        err := fmt.Errorf("query argument {{.ParamName}} is required, but not found")
         siw.ErrorHandlerFunc(w, r, &RequiredParamError{err})
         return
       }

--- a/pkg/codegen/templates/templates.gen.go
+++ b/pkg/codegen/templates/templates.gen.go
@@ -165,14 +165,14 @@ func (siw *ServerInterfaceWrapper) {{$opid}}(w http.ResponseWriter, r *http.Requ
   {{end}}
   {{if .IsJson}}
   if err := json.Unmarshal([]byte(chi.URLParam(r, "{{.ParamName}}")), &{{$varName}}); err != nil {
-    err = fmt.Errorf("Error unmarshaling parameter '{{.ParamName}}' as JSON: %w", err)
+    err = fmt.Errorf("error unmarshaling parameter '{{.ParamName}}' as JSON: %w", err)
     siw.ErrorHandlerFunc(w, r, &UnmarshalingParamError{err})
     return
   }
   {{end}}
   {{if .IsStyled}}
   if err := runtime.BindStyledParameter("{{.Style}}",{{.Explode}}, "{{.ParamName}}", chi.URLParam(r, "{{.ParamName}}"), &{{$varName}}); err != nil {
-    err = fmt.Errorf("Invalid format for parameter {{.ParamName}}: %w", err)
+    err = fmt.Errorf("invalid format for parameter {{.ParamName}}: %w", err)
     siw.ErrorHandlerFunc(w, r, &InvalidParamFormatError{err})
     return
   }
@@ -198,7 +198,7 @@ func (siw *ServerInterfaceWrapper) {{$opid}}(w http.ResponseWriter, r *http.Requ
       {{if .IsJson}}
         var value {{.TypeDef}}
         if err := json.Unmarshal([]byte(paramValue), &value); err != nil {
-          err = fmt.Errorf("Error unmarshaling parameter '{{.ParamName}}' as JSON: %w", err)
+          err = fmt.Errorf("error unmarshaling parameter '{{.ParamName}}' as JSON: %w", err)
           siw.ErrorHandlerFunc(w, r, &UnmarshalingParamError{err})
           return
         }
@@ -206,13 +206,13 @@ func (siw *ServerInterfaceWrapper) {{$opid}}(w http.ResponseWriter, r *http.Requ
         params.{{.GoName}} = {{if not .Required}}&{{end}}value
       {{end}}
       }{{if .Required}} else {
-          err := fmt.Errorf("Query argument {{.ParamName}} is required, but not found")
+          err := fmt.Errorf("query argument {{.ParamName}} is required, but not found")
           siw.ErrorHandlerFunc(w, r, &RequiredParamError{err})
           return
       }{{end}}
       {{if .IsStyled}}
       if err := runtime.BindQueryParameter("{{.Style}}", {{.Explode}}, {{.Required}}, "{{.ParamName}}", r.URL.Query(), &params.{{.GoName}}); err != nil {
-        err = fmt.Errorf("Invalid format for parameter {{.ParamName}}: %w", err)
+        err = fmt.Errorf("invalid format for parameter {{.ParamName}}: %w", err)
         siw.ErrorHandlerFunc(w, r, &InvalidParamFormatError{err})
         return
       }
@@ -227,7 +227,7 @@ func (siw *ServerInterfaceWrapper) {{$opid}}(w http.ResponseWriter, r *http.Requ
           var {{.GoName}} {{.TypeDef}}
           n := len(valueList)
           if n != 1 {
-            err := fmt.Errorf("Expected one value for {{.ParamName}}, got %d", n)
+            err := fmt.Errorf("expected one value for {{.ParamName}}, got %d", n)
             siw.ErrorHandlerFunc(w, r, &TooManyValuesForParamError{err})
             return
           }
@@ -238,7 +238,7 @@ func (siw *ServerInterfaceWrapper) {{$opid}}(w http.ResponseWriter, r *http.Requ
 
         {{if .IsJson}}
           if err := json.Unmarshal([]byte(valueList[0]), &{{.GoName}}); err != nil {
-            err = fmt.Errorf("Error unmarshaling parameter '{{.ParamName}}' as JSON: %w", err)
+            err = fmt.Errorf("error unmarshaling parameter '{{.ParamName}}' as JSON: %w", err)
             siw.ErrorHandlerFunc(w, r, &UnmarshalingParamError{err})
             return
           }
@@ -246,7 +246,7 @@ func (siw *ServerInterfaceWrapper) {{$opid}}(w http.ResponseWriter, r *http.Requ
 
         {{if .IsStyled}}
           if err := runtime.BindStyledParameterWithLocation("{{.Style}}",{{.Explode}}, "{{.ParamName}}", runtime.ParamLocationHeader, valueList[0], &{{.GoName}}); err != nil {
-            err = fmt.Errorf("Invalid format for parameter {{.ParamName}}: %w", err)
+            err = fmt.Errorf("invalid format for parameter {{.ParamName}}: %w", err)
             siw.ErrorHandlerFunc(w, r, &InvalidParamFormatError{err})
             return
           }
@@ -255,7 +255,7 @@ func (siw *ServerInterfaceWrapper) {{$opid}}(w http.ResponseWriter, r *http.Requ
           params.{{.GoName}} = {{if not .Required}}&{{end}}{{.GoName}}
 
         } {{if .Required}}else {
-            err := fmt.Errorf("Header parameter {{.ParamName}} is required, but not found")
+            err := fmt.Errorf("header parameter {{.ParamName}} is required, but not found")
             siw.ErrorHandlerFunc(w, r, &RequiredHeaderError{err})
             return
         }{{end}}
@@ -275,14 +275,14 @@ func (siw *ServerInterfaceWrapper) {{$opid}}(w http.ResponseWriter, r *http.Requ
         var decoded string
         decoded, err := url.QueryUnescape(cookie.Value)
         if err != nil {
-          err = fmt.Errorf("Error unescaping cookie parameter '{{.ParamName}}'")
+          err = fmt.Errorf("error unescaping cookie parameter '{{.ParamName}}'")
           siw.ErrorHandlerFunc(w, r, &UnescapedCookieParamError{err})
           return
         }
 
         err = json.Unmarshal([]byte(decoded), &value)
         if err != nil {
-          err = fmt.Errorf("Error unmarshaling parameter '{{.ParamName}}' as JSON: %w", err)
+          err = fmt.Errorf("error unmarshaling parameter '{{.ParamName}}' as JSON: %w", err)
           siw.ErrorHandlerFunc(w, r, &UnmarshalingParamError{err})
           return
         }
@@ -293,7 +293,7 @@ func (siw *ServerInterfaceWrapper) {{$opid}}(w http.ResponseWriter, r *http.Requ
       {{- if .IsStyled}}
         var value {{.TypeDef}}
         if err := runtime.BindStyledParameter("simple",{{.Explode}}, "{{.ParamName}}", cookie.Value, &value); err != nil {
-          err = fmt.Errorf("Invalid format for parameter {{.ParamName}}: %w", err)
+          err = fmt.Errorf("invalid format for parameter {{.ParamName}}: %w", err)
           siw.ErrorHandlerFunc(w, r, &InvalidParamFormatError{err})
           return
         }
@@ -303,7 +303,7 @@ func (siw *ServerInterfaceWrapper) {{$opid}}(w http.ResponseWriter, r *http.Requ
       }
 
       {{- if .Required}} else {
-        err := fmt.Errorf("Query argument {{.ParamName}} is required, but not found")
+        err := fmt.Errorf("query argument {{.ParamName}} is required, but not found")
         siw.ErrorHandlerFunc(w, r, &RequiredParamError{err})
         return
       }

--- a/pkg/codegen/utils.go
+++ b/pkg/codegen/utils.go
@@ -29,7 +29,7 @@ import (
 var pathParamRE *regexp.Regexp
 
 func init() {
-	pathParamRE = regexp.MustCompile("{[.;?]?([^{}*]+)\\*?}")
+	pathParamRE = regexp.MustCompile(`{[.;?]?([^{}*]+)\*?}`)
 }
 
 // Uppercase the first character in a string. This assumes UTF-8, so we have


### PR DESCRIPTION
- move to snaker to fix bad camel-casing and let the lib handle it
- fix formatting of the readme
- update error strings, as they should not be capitalized
- add tests for GoVariableName function, to ensure it generates correct names

fixes: #23