### PR TITLE
specify that the package param is required

### DIFF
--- a/goapi-gen.go
+++ b/goapi-gen.go
@@ -162,6 +162,7 @@ func main() {
 				Usage:       "The package name for generated code.",
 				DefaultText: "swagger file name",
 				Destination: &f.PackageName,
+				Required:    true,
 			},
 			&cli.StringSliceFlag{
 				Name:        GenerateKey,


### PR DESCRIPTION
If `-p` is omitted the ambiguous error message is:
`error: could not generate code: error formatting Go code: .go:6:1: expected 'IDENT', found 'import'`