### PR TITLE
Validate security before other request components

### DIFF
--- a/pkg/middleware/oapi_validate_test.go
+++ b/pkg/middleware/oapi_validate_test.go
@@ -84,6 +84,23 @@ paths:
       responses:
         '401':
           description: no content
+    post:
+      operationId: createProtectedResource
+      security:
+        - BearerAuth:
+          - unauthorized
+      responses:
+        '401':
+          description: No content
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              properties:
+                name:
+                  type: string
+
 components:
   securitySchemes:
     BearerAuth:
@@ -186,6 +203,19 @@ func TestOapiRequestValidatorWithOptions(t *testing.T) {
 	// Call a protected function without credentials
 	{
 		rec := doGet(t, r, "http://example.com/protected_resource_401")
+		assert.Equal(t, http.StatusUnauthorized, rec.Code)
+		assert.False(t, called, "Handler should not have been called")
+		called = false
+	}
+
+	// Call a protected function without credentials and malformed request
+	{
+		body := struct {
+			Name int `json:"name"`
+		}{
+			Name: 7,
+		}
+		rec := doPost(t, r, "http://example.com/protected_resource_401", body)
 		assert.Equal(t, http.StatusUnauthorized, rec.Code)
 		assert.False(t, called, "Handler should not have been called")
 		called = false


### PR DESCRIPTION
kin-openapi's openapi3filter package verifies other parts of the spec before security. This PR ensures goapi-gen's middleware validates security before verifying other parts of the request.

Closes #69 