### PR TITLE
Unmarshaling string to enum produces empty value

### DIFF
--- a/internal/test/schemas/schemas.gen.go
+++ b/internal/test/schemas/schemas.gen.go
@@ -73,20 +73,20 @@ type EnumInObjInArrayVal struct {
 	value string
 }
 
-func (t EnumInObjInArrayVal) ToValue() string {
+func (t *EnumInObjInArrayVal) ToValue() string {
 	return t.value
 }
-func (t EnumInObjInArrayVal) MarshalJSON() ([]byte, error) {
+func (t *EnumInObjInArrayVal) MarshalJSON() ([]byte, error) {
 	return json.Marshal(t.value)
 }
-func (t EnumInObjInArrayVal) UnmarshalJSON(data []byte) error {
+func (t *EnumInObjInArrayVal) UnmarshalJSON(data []byte) error {
 	var value string
 	if err := json.Unmarshal(data, &value); err != nil {
 		return err
 	}
-	return nil
+	return t.FromValue(value)
 }
-func (t EnumInObjInArrayVal) FromValue(value string) error {
+func (t *EnumInObjInArrayVal) FromValue(value string) error {
 	switch value {
 
 	case EnumInObjInArrayValFirst.value:

--- a/pkg/codegen/codegen_test.go
+++ b/pkg/codegen/codegen_test.go
@@ -355,20 +355,20 @@ func TestGenerateEnumTypes(t *testing.T) {
 type MyType struct {
     value string
 }
-func (t MyType) ToValue() string {
+func (t *MyType) ToValue() string {
     return t.value
 }
-func (t MyType) MarshalJSON() ([]byte, error) {
+func (t *MyType) MarshalJSON() ([]byte, error) {
     return json.Marshal(t.value)
 }
-func (t MyType) UnmarshalJSON(data []byte) error {
+func (t *MyType) UnmarshalJSON(data []byte) error {
     var value string
     if err := json.Unmarshal(data, &value); err != nil {
         return err
     }
-    return nil
+    return t.FromValue(value)
 }
-func (t MyType) FromValue(value string) error {
+func (t *MyType) FromValue(value string) error {
     switch value {
     
     case some.value:
@@ -397,20 +397,20 @@ func (t MyType) FromValue(value string) error {
 type MyType struct {
     value int64
 }
-func (t MyType) ToValue() int64 {
+func (t *MyType) ToValue() int64 {
     return t.value
 }
-func (t MyType) MarshalJSON() ([]byte, error) {
+func (t *MyType) MarshalJSON() ([]byte, error) {
     return json.Marshal(t.value)
 }
-func (t MyType) UnmarshalJSON(data []byte) error {
+func (t *MyType) UnmarshalJSON(data []byte) error {
     var value int64
     if err := json.Unmarshal(data, &value); err != nil {
         return err
     }
-    return nil
+    return t.FromValue(value)
 }
-func (t MyType) FromValue(value int64) error {
+func (t *MyType) FromValue(value int64) error {
     switch value {
     
     case some.value:

--- a/pkg/codegen/templates/enum-typedef.tmpl
+++ b/pkg/codegen/templates/enum-typedef.tmpl
@@ -3,20 +3,20 @@
 type {{.TypeName}} struct {
     value {{.Schema.TypeDecl}}
 }
-func (t {{.TypeName}}) ToValue() {{.Schema.TypeDecl}} {
+func (t *{{.TypeName}}) ToValue() {{.Schema.TypeDecl}} {
     return t.value
 }
-func (t {{.TypeName}}) MarshalJSON() ([]byte, error) {
+func (t *{{.TypeName}}) MarshalJSON() ([]byte, error) {
     return json.Marshal(t.value)
 }
-func (t {{.TypeName}}) UnmarshalJSON(data []byte) error {
+func (t *{{.TypeName}}) UnmarshalJSON(data []byte) error {
     var value {{.Schema.TypeDecl}}
     if err := json.Unmarshal(data, &value); err != nil {
         return err
     }
-    return nil
+    return t.FromValue(value)
 }
-func (t {{.TypeName}}) FromValue(value {{.Schema.TypeDecl}}) error {
+func (t *{{.TypeName}}) FromValue(value {{.Schema.TypeDecl}}) error {
     switch value {
     {{range $valueName, $value := .Schema.EnumValues}}
     case {{$valueName}}.value:


### PR DESCRIPTION
Unmarshalling a string to an enum currently unmarshals an empty string because the value is never set and persisted internally.

This MR fixes two issues:

- UnmarshalJSON never updated the internal value after unmarshaling.
- Methods must have a pointer receiver for updates to take effect.