### PR TITLE
Add Error Response Content Type customization options

### DIFF
--- a/pkg/middleware/oapi_validate.go
+++ b/pkg/middleware/oapi_validate.go
@@ -52,9 +52,9 @@ func OapiRequestValidatorWithOptions(swagger *openapi3.T, options *Options) func
 
 			// validate request
 			if statusCode, err := validateRequest(r, router, options); err != nil {
-				contentType := options.ErrRespContentType
-				if contentType == "" {
-					contentType = ErrRespContentTypePlain
+				contentType := ErrRespContentTypePlain
+				if options != nil && options.ErrRespContentType != "" {
+					contentType = options.ErrRespContentType
 				}
 				w.Header().Set("Content-Type", string(contentType)+"; charset=utf-8")
 				w.Header().Set("X-Content-Type-Options", "nosniff")

--- a/pkg/middleware/oapi_validate.go
+++ b/pkg/middleware/oapi_validate.go
@@ -23,6 +23,7 @@ type Options struct {
 	ErrRespContentType
 }
 
+// ErrRespContentType represents the support content-types for the response when a validation error occurs
 type ErrRespContentType string
 
 // Consts to expose supported Error Response Content-Types

--- a/pkg/middleware/oapi_validate_test.go
+++ b/pkg/middleware/oapi_validate_test.go
@@ -150,7 +150,7 @@ func TestOapiRequestValidatorWithOptions(t *testing.T) {
 
 	// Set up an authenticator to check authenticated function. It will allow
 	// access to "someScope", but disallow others.
-	options := Options{
+	options := &Options{
 		Options: openapi3filter.Options{
 			AuthenticationFunc: func(c context.Context, input *openapi3filter.AuthenticationInput) error {
 				for _, s := range input.Scopes {
@@ -164,7 +164,7 @@ func TestOapiRequestValidatorWithOptions(t *testing.T) {
 	}
 
 	// register middleware
-	r.Use(OapiRequestValidatorWithOptions(swagger, &options))
+	r.Use(OapiRequestValidatorWithOptions(swagger, options))
 
 	// basic cases
 	testRequestValidatorBasicFunctions(t, r)
@@ -218,6 +218,46 @@ func TestOapiRequestValidatorWithOptions(t *testing.T) {
 		rec := doPost(t, r, "http://example.com/protected_resource_401", body)
 		assert.Equal(t, http.StatusUnauthorized, rec.Code)
 		assert.False(t, called, "Handler should not have been called")
+		assert.Contains(t, rec.Result().Header["Content-Type"][0], ErrRespContentTypePlain)
+		called = false
+	}
+
+	// Confirm explicit text/plain content-type is returned
+	{
+		options.ErrRespContentType = ErrRespContentTypePlain
+		body := struct {
+			Name int `json:"name"`
+		}{
+			Name: 7,
+		}
+		rec := doPost(t, r, "http://example.com/protected_resource_401", body)
+		assert.Contains(t, rec.Result().Header["Content-Type"][0], ErrRespContentTypePlain)
+		called = false
+	}
+
+	// Confirm explicit application/json content-type is returned
+	{
+		options.ErrRespContentType = ErrRespContentTypeJSON
+		body := struct {
+			Name int `json:"name"`
+		}{
+			Name: 7,
+		}
+		rec := doPost(t, r, "http://example.com/protected_resource_401", body)
+		assert.Contains(t, rec.Result().Header["Content-Type"][0], ErrRespContentTypeJSON)
+		called = false
+	}
+
+	// Confirm explicit application/xml content-type is returned
+	{
+		options.ErrRespContentType = ErrRespContentTypeXML
+		body := struct {
+			Name int `json:"name"`
+		}{
+			Name: 7,
+		}
+		rec := doPost(t, r, "http://example.com/protected_resource_401", body)
+		assert.Contains(t, rec.Result().Header["Content-Type"][0], ErrRespContentTypeXML)
 		called = false
 	}
 }

--- a/pkg/middleware/oapi_validate_test.go
+++ b/pkg/middleware/oapi_validate_test.go
@@ -143,6 +143,11 @@ func TestOapiRequestValidator(t *testing.T) {
 }
 
 func TestOapiRequestValidatorWithOptions(t *testing.T) {
+	malformedBody := struct {
+		Name int `json:"name"`
+	}{
+		Name: 7,
+	}
 	swagger, err := openapi3.NewLoader().LoadFromData([]byte(testSchema))
 	require.NoError(t, err, "Error initializing swagger")
 
@@ -210,11 +215,7 @@ func TestOapiRequestValidatorWithOptions(t *testing.T) {
 
 	// Call a protected function without credentials and malformed request
 	{
-		body := struct {
-			Name int `json:"name"`
-		}{
-			Name: 7,
-		}
+		body := malformedBody
 		rec := doPost(t, r, "http://example.com/protected_resource_401", body)
 		assert.Equal(t, http.StatusUnauthorized, rec.Code)
 		assert.False(t, called, "Handler should not have been called")
@@ -225,11 +226,7 @@ func TestOapiRequestValidatorWithOptions(t *testing.T) {
 	// Confirm explicit text/plain content-type is returned
 	{
 		options.ErrRespContentType = ErrRespContentTypePlain
-		body := struct {
-			Name int `json:"name"`
-		}{
-			Name: 7,
-		}
+		body := malformedBody
 		rec := doPost(t, r, "http://example.com/protected_resource_401", body)
 		assert.Contains(t, rec.Result().Header["Content-Type"][0], ErrRespContentTypePlain)
 		called = false
@@ -238,11 +235,7 @@ func TestOapiRequestValidatorWithOptions(t *testing.T) {
 	// Confirm explicit application/json content-type is returned
 	{
 		options.ErrRespContentType = ErrRespContentTypeJSON
-		body := struct {
-			Name int `json:"name"`
-		}{
-			Name: 7,
-		}
+		body := malformedBody
 		rec := doPost(t, r, "http://example.com/protected_resource_401", body)
 		assert.Contains(t, rec.Result().Header["Content-Type"][0], ErrRespContentTypeJSON)
 		called = false
@@ -251,11 +244,7 @@ func TestOapiRequestValidatorWithOptions(t *testing.T) {
 	// Confirm explicit application/xml content-type is returned
 	{
 		options.ErrRespContentType = ErrRespContentTypeXML
-		body := struct {
-			Name int `json:"name"`
-		}{
-			Name: 7,
-		}
+		body := malformedBody
 		rec := doPost(t, r, "http://example.com/protected_resource_401", body)
 		assert.Contains(t, rec.Result().Header["Content-Type"][0], ErrRespContentTypeXML)
 		called = false


### PR DESCRIPTION
Resolves https://github.com/discord-gophers/goapi-gen/issues/74.

Adds the ability to specify how you would like the validate middleware to decorate the response (content-type header) in the case of an error.

I've included a couple of tests to ensure the specified content type is set in the response header during an error.