### PR TITLE
Require handlers to return *Response directly

### DIFF
--- a/examples/petstore-expanded/api/petstore.gen.go
+++ b/examples/petstore-expanded/api/petstore.gen.go
@@ -179,16 +179,16 @@ func FindPetByIDJSONDefaultResponse(body Error) *Response {
 type ServerInterface interface {
 	// Returns all pets
 	// (GET /pets)
-	FindPets(w http.ResponseWriter, r *http.Request, params FindPetsParams)
+	FindPets(w http.ResponseWriter, r *http.Request, params FindPetsParams) *Response
 	// Creates a new pet
 	// (POST /pets)
-	AddPet(w http.ResponseWriter, r *http.Request)
+	AddPet(w http.ResponseWriter, r *http.Request) *Response
 	// Deletes a pet by ID
 	// (DELETE /pets/{id})
-	DeletePet(w http.ResponseWriter, r *http.Request, id int64)
+	DeletePet(w http.ResponseWriter, r *http.Request, id int64) *Response
 	// Returns a pet by ID
 	// (GET /pets/{id})
-	FindPetByID(w http.ResponseWriter, r *http.Request, id int64)
+	FindPetByID(w http.ResponseWriter, r *http.Request, id int64) *Response
 }
 
 // ServerInterfaceWrapper converts contexts to parameters.
@@ -222,7 +222,10 @@ func (siw *ServerInterfaceWrapper) FindPets(w http.ResponseWriter, r *http.Reque
 	}
 
 	var handler = http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-		siw.Handler.FindPets(w, r, params)
+		resp := siw.Handler.FindPets(w, r, params)
+		if resp != nil {
+			render.Render(w, r, resp)
+		}
 	})
 
 	handler(w, r.WithContext(ctx))
@@ -233,7 +236,10 @@ func (siw *ServerInterfaceWrapper) AddPet(w http.ResponseWriter, r *http.Request
 	ctx := r.Context()
 
 	var handler = http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-		siw.Handler.AddPet(w, r)
+		resp := siw.Handler.AddPet(w, r)
+		if resp != nil {
+			render.Render(w, r, resp)
+		}
 	})
 
 	handler(w, r.WithContext(ctx))
@@ -253,7 +259,10 @@ func (siw *ServerInterfaceWrapper) DeletePet(w http.ResponseWriter, r *http.Requ
 	}
 
 	var handler = http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-		siw.Handler.DeletePet(w, r, id)
+		resp := siw.Handler.DeletePet(w, r, id)
+		if resp != nil {
+			render.Render(w, r, resp)
+		}
 	})
 
 	handler(w, r.WithContext(ctx))
@@ -273,7 +282,10 @@ func (siw *ServerInterfaceWrapper) FindPetByID(w http.ResponseWriter, r *http.Re
 	}
 
 	var handler = http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-		siw.Handler.FindPetByID(w, r, id)
+		resp := siw.Handler.FindPetByID(w, r, id)
+		if resp != nil {
+			render.Render(w, r, resp)
+		}
 	})
 
 	handler(w, r.WithContext(ctx))

--- a/examples/petstore-expanded/api/petstore.go
+++ b/examples/petstore-expanded/api/petstore.go
@@ -30,7 +30,7 @@ func NewPetStore() *PetStore {
 const petNotFoundMsg = "Could not find pet with ID %d"
 
 // Here, we implement all of the handlers in the ServerInterface
-func (p *PetStore) FindPets(w http.ResponseWriter, r *http.Request, params FindPetsParams) {
+func (p *PetStore) FindPets(w http.ResponseWriter, r *http.Request, params FindPetsParams) *Response {
 	p.Lock.Lock()
 	defer p.Lock.Unlock()
 
@@ -58,18 +58,14 @@ func (p *PetStore) FindPets(w http.ResponseWriter, r *http.Request, params FindP
 		}
 	}
 
-	render.Render(w, r, FindPetsJSON200Response(result))
+	return FindPetsJSON200Response(result)
 }
 
-func (p *PetStore) AddPet(w http.ResponseWriter, r *http.Request) {
+func (p *PetStore) AddPet(w http.ResponseWriter, r *http.Request) *Response {
 	// We expect a NewPet object in the request body.
 	var newPet AddPetJSONRequestBody
 	if err := render.Bind(r, &newPet); err != nil {
-		render.Render(
-			w, r,
-			AddPetJSONDefaultResponse(Error{"Invalid format for NewPet"}).Status(http.StatusBadRequest),
-		)
-		return
+		return AddPetJSONDefaultResponse(Error{"Invalid format for NewPet"}).Status(http.StatusBadRequest)
 	}
 
 	// We now have a pet, let's add it to our "database".
@@ -89,38 +85,31 @@ func (p *PetStore) AddPet(w http.ResponseWriter, r *http.Request) {
 	p.Pets[pet.ID] = pet
 
 	// Now, we have to return the NewPet
-	render.Render(w, r, AddPetJSON201Response(pet))
+	return AddPetJSON201Response(pet)
 }
 
-func (p *PetStore) FindPetByID(w http.ResponseWriter, r *http.Request, id int64) {
+func (p *PetStore) FindPetByID(w http.ResponseWriter, r *http.Request, id int64) *Response {
 	p.Lock.Lock()
 	defer p.Lock.Unlock()
 
 	pet, found := p.Pets[id]
 	if !found {
-		render.Render(
-			w, r,
-			FindPetByIDJSONDefaultResponse(Error{fmt.Sprintf(petNotFoundMsg, id)}).Status(http.StatusNotFound),
-		)
-		return
+		return FindPetByIDJSONDefaultResponse(Error{fmt.Sprintf(petNotFoundMsg, id)}).Status(http.StatusNotFound)
 	}
 
-	render.Render(w, r, FindPetByIDJSON200Response(pet))
+	return FindPetByIDJSON200Response(pet)
 }
 
-func (p *PetStore) DeletePet(w http.ResponseWriter, r *http.Request, id int64) {
+func (p *PetStore) DeletePet(w http.ResponseWriter, r *http.Request, id int64) *Response {
 	p.Lock.Lock()
 	defer p.Lock.Unlock()
 
 	_, found := p.Pets[id]
 	if !found {
-		render.Render(
-			w, r,
-			DeletePetJSONDefaultResponse(Error{fmt.Sprintf(petNotFoundMsg, id)}).Status(http.StatusNotFound),
-		)
-		return
+		return DeletePetJSONDefaultResponse(Error{fmt.Sprintf(petNotFoundMsg, id)}).Status(http.StatusNotFound)
 	}
 	delete(p.Pets, id)
 
 	w.WriteHeader(http.StatusNoContent)
+	return nil
 }

--- a/internal/test/components/components.gen.go
+++ b/internal/test/components/components.gen.go
@@ -810,13 +810,13 @@ func (a AdditionalPropertiesObject5) MarshalJSON() ([]byte, error) {
 type ServerInterface interface {
 
 	// (GET /ensure-everything-is-referenced)
-	EnsureEverythingIsReferenced(w http.ResponseWriter, r *http.Request)
+	EnsureEverythingIsReferenced(w http.ResponseWriter, r *http.Request) *Response
 
 	// (GET /params_with_add_props)
-	ParamsWithAddProps(w http.ResponseWriter, r *http.Request, params ParamsWithAddPropsParams)
+	ParamsWithAddProps(w http.ResponseWriter, r *http.Request, params ParamsWithAddPropsParams) *Response
 
 	// (POST /params_with_add_props)
-	BodyWithAddProps(w http.ResponseWriter, r *http.Request)
+	BodyWithAddProps(w http.ResponseWriter, r *http.Request) *Response
 }
 
 // ServerInterfaceWrapper converts contexts to parameters.
@@ -831,7 +831,10 @@ func (siw *ServerInterfaceWrapper) EnsureEverythingIsReferenced(w http.ResponseW
 	ctx := r.Context()
 
 	var handler = http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-		siw.Handler.EnsureEverythingIsReferenced(w, r)
+		resp := siw.Handler.EnsureEverythingIsReferenced(w, r)
+		if resp != nil {
+			render.Render(w, r, resp)
+		}
 	})
 
 	handler(w, r.WithContext(ctx))
@@ -861,7 +864,10 @@ func (siw *ServerInterfaceWrapper) ParamsWithAddProps(w http.ResponseWriter, r *
 	}
 
 	var handler = http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-		siw.Handler.ParamsWithAddProps(w, r, params)
+		resp := siw.Handler.ParamsWithAddProps(w, r, params)
+		if resp != nil {
+			render.Render(w, r, resp)
+		}
 	})
 
 	handler(w, r.WithContext(ctx))
@@ -872,7 +878,10 @@ func (siw *ServerInterfaceWrapper) BodyWithAddProps(w http.ResponseWriter, r *ht
 	ctx := r.Context()
 
 	var handler = http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-		siw.Handler.BodyWithAddProps(w, r)
+		resp := siw.Handler.BodyWithAddProps(w, r)
+		if resp != nil {
+			render.Render(w, r, resp)
+		}
 	})
 
 	handler(w, r.WithContext(ctx))

--- a/internal/test/parameters/parameters.gen.go
+++ b/internal/test/parameters/parameters.gen.go
@@ -168,64 +168,64 @@ func (resp *Response) MarshalXML(e *xml.Encoder, start xml.StartElement) error {
 type ServerInterface interface {
 
 	// (GET /contentObject/{param})
-	GetContentObject(w http.ResponseWriter, r *http.Request, param ComplexObject)
+	GetContentObject(w http.ResponseWriter, r *http.Request, param ComplexObject) *Response
 
 	// (GET /cookie)
-	GetCookie(w http.ResponseWriter, r *http.Request, params GetCookieParams)
+	GetCookie(w http.ResponseWriter, r *http.Request, params GetCookieParams) *Response
 
 	// (GET /header)
-	GetHeader(w http.ResponseWriter, r *http.Request, params GetHeaderParams)
+	GetHeader(w http.ResponseWriter, r *http.Request, params GetHeaderParams) *Response
 
 	// (GET /labelExplodeArray/{.param*})
-	GetLabelExplodeArray(w http.ResponseWriter, r *http.Request, param []int32)
+	GetLabelExplodeArray(w http.ResponseWriter, r *http.Request, param []int32) *Response
 
 	// (GET /labelExplodeObject/{.param*})
-	GetLabelExplodeObject(w http.ResponseWriter, r *http.Request, param Object)
+	GetLabelExplodeObject(w http.ResponseWriter, r *http.Request, param Object) *Response
 
 	// (GET /labelNoExplodeArray/{.param})
-	GetLabelNoExplodeArray(w http.ResponseWriter, r *http.Request, param []int32)
+	GetLabelNoExplodeArray(w http.ResponseWriter, r *http.Request, param []int32) *Response
 
 	// (GET /labelNoExplodeObject/{.param})
-	GetLabelNoExplodeObject(w http.ResponseWriter, r *http.Request, param Object)
+	GetLabelNoExplodeObject(w http.ResponseWriter, r *http.Request, param Object) *Response
 
 	// (GET /matrixExplodeArray/{.id*})
-	GetMatrixExplodeArray(w http.ResponseWriter, r *http.Request, id []int32)
+	GetMatrixExplodeArray(w http.ResponseWriter, r *http.Request, id []int32) *Response
 
 	// (GET /matrixExplodeObject/{.id*})
-	GetMatrixExplodeObject(w http.ResponseWriter, r *http.Request, id Object)
+	GetMatrixExplodeObject(w http.ResponseWriter, r *http.Request, id Object) *Response
 
 	// (GET /matrixNoExplodeArray/{.id})
-	GetMatrixNoExplodeArray(w http.ResponseWriter, r *http.Request, id []int32)
+	GetMatrixNoExplodeArray(w http.ResponseWriter, r *http.Request, id []int32) *Response
 
 	// (GET /matrixNoExplodeObject/{.id})
-	GetMatrixNoExplodeObject(w http.ResponseWriter, r *http.Request, id Object)
+	GetMatrixNoExplodeObject(w http.ResponseWriter, r *http.Request, id Object) *Response
 
 	// (GET /passThrough/{param})
-	GetPassThrough(w http.ResponseWriter, r *http.Request, param string)
+	GetPassThrough(w http.ResponseWriter, r *http.Request, param string) *Response
 
 	// (GET /queryDeepObject)
-	GetDeepObject(w http.ResponseWriter, r *http.Request, params GetDeepObjectParams)
+	GetDeepObject(w http.ResponseWriter, r *http.Request, params GetDeepObjectParams) *Response
 
 	// (GET /queryForm)
-	GetQueryForm(w http.ResponseWriter, r *http.Request, params GetQueryFormParams)
+	GetQueryForm(w http.ResponseWriter, r *http.Request, params GetQueryFormParams) *Response
 
 	// (GET /simpleExplodeArray/{param*})
-	GetSimpleExplodeArray(w http.ResponseWriter, r *http.Request, param []int32)
+	GetSimpleExplodeArray(w http.ResponseWriter, r *http.Request, param []int32) *Response
 
 	// (GET /simpleExplodeObject/{param*})
-	GetSimpleExplodeObject(w http.ResponseWriter, r *http.Request, param Object)
+	GetSimpleExplodeObject(w http.ResponseWriter, r *http.Request, param Object) *Response
 
 	// (GET /simpleNoExplodeArray/{param})
-	GetSimpleNoExplodeArray(w http.ResponseWriter, r *http.Request, param []int32)
+	GetSimpleNoExplodeArray(w http.ResponseWriter, r *http.Request, param []int32) *Response
 
 	// (GET /simpleNoExplodeObject/{param})
-	GetSimpleNoExplodeObject(w http.ResponseWriter, r *http.Request, param Object)
+	GetSimpleNoExplodeObject(w http.ResponseWriter, r *http.Request, param Object) *Response
 
 	// (GET /simplePrimitive/{param})
-	GetSimplePrimitive(w http.ResponseWriter, r *http.Request, param int32)
+	GetSimplePrimitive(w http.ResponseWriter, r *http.Request, param int32) *Response
 
 	// (GET /startingWithNumber/{1param})
-	GetStartingWithNumber(w http.ResponseWriter, r *http.Request, n1param string)
+	GetStartingWithNumber(w http.ResponseWriter, r *http.Request, n1param string) *Response
 }
 
 // ServerInterfaceWrapper converts contexts to parameters.
@@ -249,7 +249,10 @@ func (siw *ServerInterfaceWrapper) GetContentObject(w http.ResponseWriter, r *ht
 	}
 
 	var handler = http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-		siw.Handler.GetContentObject(w, r, param)
+		resp := siw.Handler.GetContentObject(w, r, param)
+		if resp != nil {
+			render.Render(w, r, resp)
+		}
 	})
 
 	handler(w, r.WithContext(ctx))
@@ -361,7 +364,10 @@ func (siw *ServerInterfaceWrapper) GetCookie(w http.ResponseWriter, r *http.Requ
 	}
 
 	var handler = http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-		siw.Handler.GetCookie(w, r, params)
+		resp := siw.Handler.GetCookie(w, r, params)
+		if resp != nil {
+			render.Render(w, r, resp)
+		}
 	})
 
 	handler(w, r.WithContext(ctx))
@@ -537,7 +543,10 @@ func (siw *ServerInterfaceWrapper) GetHeader(w http.ResponseWriter, r *http.Requ
 	}
 
 	var handler = http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-		siw.Handler.GetHeader(w, r, params)
+		resp := siw.Handler.GetHeader(w, r, params)
+		if resp != nil {
+			render.Render(w, r, resp)
+		}
 	})
 
 	handler(w, r.WithContext(ctx))
@@ -557,7 +566,10 @@ func (siw *ServerInterfaceWrapper) GetLabelExplodeArray(w http.ResponseWriter, r
 	}
 
 	var handler = http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-		siw.Handler.GetLabelExplodeArray(w, r, param)
+		resp := siw.Handler.GetLabelExplodeArray(w, r, param)
+		if resp != nil {
+			render.Render(w, r, resp)
+		}
 	})
 
 	handler(w, r.WithContext(ctx))
@@ -577,7 +589,10 @@ func (siw *ServerInterfaceWrapper) GetLabelExplodeObject(w http.ResponseWriter, 
 	}
 
 	var handler = http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-		siw.Handler.GetLabelExplodeObject(w, r, param)
+		resp := siw.Handler.GetLabelExplodeObject(w, r, param)
+		if resp != nil {
+			render.Render(w, r, resp)
+		}
 	})
 
 	handler(w, r.WithContext(ctx))
@@ -597,7 +612,10 @@ func (siw *ServerInterfaceWrapper) GetLabelNoExplodeArray(w http.ResponseWriter,
 	}
 
 	var handler = http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-		siw.Handler.GetLabelNoExplodeArray(w, r, param)
+		resp := siw.Handler.GetLabelNoExplodeArray(w, r, param)
+		if resp != nil {
+			render.Render(w, r, resp)
+		}
 	})
 
 	handler(w, r.WithContext(ctx))
@@ -617,7 +635,10 @@ func (siw *ServerInterfaceWrapper) GetLabelNoExplodeObject(w http.ResponseWriter
 	}
 
 	var handler = http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-		siw.Handler.GetLabelNoExplodeObject(w, r, param)
+		resp := siw.Handler.GetLabelNoExplodeObject(w, r, param)
+		if resp != nil {
+			render.Render(w, r, resp)
+		}
 	})
 
 	handler(w, r.WithContext(ctx))
@@ -637,7 +658,10 @@ func (siw *ServerInterfaceWrapper) GetMatrixExplodeArray(w http.ResponseWriter, 
 	}
 
 	var handler = http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-		siw.Handler.GetMatrixExplodeArray(w, r, id)
+		resp := siw.Handler.GetMatrixExplodeArray(w, r, id)
+		if resp != nil {
+			render.Render(w, r, resp)
+		}
 	})
 
 	handler(w, r.WithContext(ctx))
@@ -657,7 +681,10 @@ func (siw *ServerInterfaceWrapper) GetMatrixExplodeObject(w http.ResponseWriter,
 	}
 
 	var handler = http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-		siw.Handler.GetMatrixExplodeObject(w, r, id)
+		resp := siw.Handler.GetMatrixExplodeObject(w, r, id)
+		if resp != nil {
+			render.Render(w, r, resp)
+		}
 	})
 
 	handler(w, r.WithContext(ctx))
@@ -677,7 +704,10 @@ func (siw *ServerInterfaceWrapper) GetMatrixNoExplodeArray(w http.ResponseWriter
 	}
 
 	var handler = http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-		siw.Handler.GetMatrixNoExplodeArray(w, r, id)
+		resp := siw.Handler.GetMatrixNoExplodeArray(w, r, id)
+		if resp != nil {
+			render.Render(w, r, resp)
+		}
 	})
 
 	handler(w, r.WithContext(ctx))
@@ -697,7 +727,10 @@ func (siw *ServerInterfaceWrapper) GetMatrixNoExplodeObject(w http.ResponseWrite
 	}
 
 	var handler = http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-		siw.Handler.GetMatrixNoExplodeObject(w, r, id)
+		resp := siw.Handler.GetMatrixNoExplodeObject(w, r, id)
+		if resp != nil {
+			render.Render(w, r, resp)
+		}
 	})
 
 	handler(w, r.WithContext(ctx))
@@ -713,7 +746,10 @@ func (siw *ServerInterfaceWrapper) GetPassThrough(w http.ResponseWriter, r *http
 	param = chi.URLParam(r, "param")
 
 	var handler = http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-		siw.Handler.GetPassThrough(w, r, param)
+		resp := siw.Handler.GetPassThrough(w, r, param)
+		if resp != nil {
+			render.Render(w, r, resp)
+		}
 	})
 
 	handler(w, r.WithContext(ctx))
@@ -735,7 +771,10 @@ func (siw *ServerInterfaceWrapper) GetDeepObject(w http.ResponseWriter, r *http.
 	}
 
 	var handler = http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-		siw.Handler.GetDeepObject(w, r, params)
+		resp := siw.Handler.GetDeepObject(w, r, params)
+		if resp != nil {
+			render.Render(w, r, resp)
+		}
 	})
 
 	handler(w, r.WithContext(ctx))
@@ -827,7 +866,10 @@ func (siw *ServerInterfaceWrapper) GetQueryForm(w http.ResponseWriter, r *http.R
 	}
 
 	var handler = http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-		siw.Handler.GetQueryForm(w, r, params)
+		resp := siw.Handler.GetQueryForm(w, r, params)
+		if resp != nil {
+			render.Render(w, r, resp)
+		}
 	})
 
 	handler(w, r.WithContext(ctx))
@@ -847,7 +889,10 @@ func (siw *ServerInterfaceWrapper) GetSimpleExplodeArray(w http.ResponseWriter, 
 	}
 
 	var handler = http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-		siw.Handler.GetSimpleExplodeArray(w, r, param)
+		resp := siw.Handler.GetSimpleExplodeArray(w, r, param)
+		if resp != nil {
+			render.Render(w, r, resp)
+		}
 	})
 
 	handler(w, r.WithContext(ctx))
@@ -867,7 +912,10 @@ func (siw *ServerInterfaceWrapper) GetSimpleExplodeObject(w http.ResponseWriter,
 	}
 
 	var handler = http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-		siw.Handler.GetSimpleExplodeObject(w, r, param)
+		resp := siw.Handler.GetSimpleExplodeObject(w, r, param)
+		if resp != nil {
+			render.Render(w, r, resp)
+		}
 	})
 
 	handler(w, r.WithContext(ctx))
@@ -887,7 +935,10 @@ func (siw *ServerInterfaceWrapper) GetSimpleNoExplodeArray(w http.ResponseWriter
 	}
 
 	var handler = http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-		siw.Handler.GetSimpleNoExplodeArray(w, r, param)
+		resp := siw.Handler.GetSimpleNoExplodeArray(w, r, param)
+		if resp != nil {
+			render.Render(w, r, resp)
+		}
 	})
 
 	handler(w, r.WithContext(ctx))
@@ -907,7 +958,10 @@ func (siw *ServerInterfaceWrapper) GetSimpleNoExplodeObject(w http.ResponseWrite
 	}
 
 	var handler = http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-		siw.Handler.GetSimpleNoExplodeObject(w, r, param)
+		resp := siw.Handler.GetSimpleNoExplodeObject(w, r, param)
+		if resp != nil {
+			render.Render(w, r, resp)
+		}
 	})
 
 	handler(w, r.WithContext(ctx))
@@ -927,7 +981,10 @@ func (siw *ServerInterfaceWrapper) GetSimplePrimitive(w http.ResponseWriter, r *
 	}
 
 	var handler = http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-		siw.Handler.GetSimplePrimitive(w, r, param)
+		resp := siw.Handler.GetSimplePrimitive(w, r, param)
+		if resp != nil {
+			render.Render(w, r, resp)
+		}
 	})
 
 	handler(w, r.WithContext(ctx))
@@ -943,7 +1000,10 @@ func (siw *ServerInterfaceWrapper) GetStartingWithNumber(w http.ResponseWriter, 
 	n1param = chi.URLParam(r, "1param")
 
 	var handler = http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-		siw.Handler.GetStartingWithNumber(w, r, n1param)
+		resp := siw.Handler.GetStartingWithNumber(w, r, n1param)
+		if resp != nil {
+			render.Render(w, r, resp)
+		}
 	})
 
 	handler(w, r.WithContext(ctx))

--- a/internal/test/parameters/parameters_test.go
+++ b/internal/test/parameters/parameters_test.go
@@ -25,7 +25,7 @@ type testServer struct {
 	headerParams    *GetHeaderParams
 }
 
-func (t *testServer) reset() {
+func (t *testServer) reset() *Response {
 	t.array = nil
 	t.object = nil
 	t.complexObject = nil
@@ -36,95 +36,113 @@ func (t *testServer) reset() {
 	t.cookieParams = nil
 	t.queryParams = nil
 	t.headerParams = nil
+	return nil
 }
 
 //  (GET /contentObject/{param})
-func (t *testServer) GetContentObject(w http.ResponseWriter, r *http.Request, param ComplexObject) {
+func (t *testServer) GetContentObject(w http.ResponseWriter, r *http.Request, param ComplexObject) *Response {
 	t.complexObject = &param
+	return nil
 }
 
 //  (GET /labelExplodeArray/{.param*})
-func (t *testServer) GetLabelExplodeArray(w http.ResponseWriter, r *http.Request, param []int32) {
+func (t *testServer) GetLabelExplodeArray(w http.ResponseWriter, r *http.Request, param []int32) *Response {
 	t.array = param
+	return nil
 }
 
 //  (GET /labelExplodeObject/{.param*})
-func (t *testServer) GetLabelExplodeObject(w http.ResponseWriter, r *http.Request, param Object) {
+func (t *testServer) GetLabelExplodeObject(w http.ResponseWriter, r *http.Request, param Object) *Response {
 	t.object = &param
+	return nil
 }
 
 //  (GET /labelNoExplodeArray/{.param})
-func (t *testServer) GetLabelNoExplodeArray(w http.ResponseWriter, r *http.Request, param []int32) {
+func (t *testServer) GetLabelNoExplodeArray(w http.ResponseWriter, r *http.Request, param []int32) *Response {
 	t.array = param
+	return nil
 }
 
 //  (GET /labelNoExplodeObject/{.param})
-func (t *testServer) GetLabelNoExplodeObject(w http.ResponseWriter, r *http.Request, param Object) {
+func (t *testServer) GetLabelNoExplodeObject(w http.ResponseWriter, r *http.Request, param Object) *Response {
 	t.object = &param
+	return nil
 }
 
 //  (GET /matrixExplodeArray/{.param*})
-func (t *testServer) GetMatrixExplodeArray(w http.ResponseWriter, r *http.Request, param []int32) {
+func (t *testServer) GetMatrixExplodeArray(w http.ResponseWriter, r *http.Request, param []int32) *Response {
 	t.array = param
+	return nil
 }
 
 //  (GET /matrixExplodeObject/{.param*})
-func (t *testServer) GetMatrixExplodeObject(w http.ResponseWriter, r *http.Request, param Object) {
+func (t *testServer) GetMatrixExplodeObject(w http.ResponseWriter, r *http.Request, param Object) *Response {
 	t.object = &param
+	return nil
 }
 
 //  (GET /matrixNoExplodeArray/{.param})
-func (t *testServer) GetMatrixNoExplodeArray(w http.ResponseWriter, r *http.Request, param []int32) {
+func (t *testServer) GetMatrixNoExplodeArray(w http.ResponseWriter, r *http.Request, param []int32) *Response {
 	t.array = param
+	return nil
 }
 
 //  (GET /matrixNoExplodeObject/{.param})
-func (t *testServer) GetMatrixNoExplodeObject(w http.ResponseWriter, r *http.Request, param Object) {
+func (t *testServer) GetMatrixNoExplodeObject(w http.ResponseWriter, r *http.Request, param Object) *Response {
 	t.object = &param
+	return nil
 }
 
 //  (GET /simpleExplodeArray/{param*})
-func (t *testServer) GetSimpleExplodeArray(w http.ResponseWriter, r *http.Request, param []int32) {
+func (t *testServer) GetSimpleExplodeArray(w http.ResponseWriter, r *http.Request, param []int32) *Response {
 	t.array = param
+	return nil
 }
 
 //  (GET /simpleExplodeObject/{param*})
-func (t *testServer) GetSimpleExplodeObject(w http.ResponseWriter, r *http.Request, param Object) {
+func (t *testServer) GetSimpleExplodeObject(w http.ResponseWriter, r *http.Request, param Object) *Response {
 	t.object = &param
+	return nil
 }
 
 //  (GET /simpleNoExplodeArray/{param})
-func (t *testServer) GetSimpleNoExplodeArray(w http.ResponseWriter, r *http.Request, param []int32) {
+func (t *testServer) GetSimpleNoExplodeArray(w http.ResponseWriter, r *http.Request, param []int32) *Response {
 	t.array = param
+	return nil
 }
 
 //  (GET /simpleNoExplodeObject/{param})
-func (t *testServer) GetSimpleNoExplodeObject(w http.ResponseWriter, r *http.Request, param Object) {
+func (t *testServer) GetSimpleNoExplodeObject(w http.ResponseWriter, r *http.Request, param Object) *Response {
 	t.object = &param
+	return nil
 }
 
 //  (GET /passThrough/{param})
-func (t *testServer) GetPassThrough(w http.ResponseWriter, r *http.Request, param string) {
+func (t *testServer) GetPassThrough(w http.ResponseWriter, r *http.Request, param string) *Response {
 	t.passThrough = &param
+	return nil
 }
 
 //  (GET /startingWithjNumber/{param})
-func (t *testServer) GetStartingWithNumber(w http.ResponseWriter, r *http.Request, n1param string) {
+func (t *testServer) GetStartingWithNumber(w http.ResponseWriter, r *http.Request, n1param string) *Response {
 	t.n1param = &n1param
+	return nil
 }
 
 // (GET /queryDeepObject)
-func (t *testServer) GetDeepObject(w http.ResponseWriter, r *http.Request, params GetDeepObjectParams) {
+func (t *testServer) GetDeepObject(w http.ResponseWriter, r *http.Request, params GetDeepObjectParams) *Response {
 	t.complexObject = &params.DeepObj
+	return nil
 }
 
 //  (GET /simplePrimitive/{param})
-func (t *testServer) GetSimplePrimitive(w http.ResponseWriter, r *http.Request, param int32) {
+func (t *testServer) GetSimplePrimitive(w http.ResponseWriter, r *http.Request, param int32) *Response {
 	t.primitive = &param
+	return nil
 }
 
 //  (GET /queryForm)
-func (t *testServer) GetQueryForm(w http.ResponseWriter, r *http.Request, params GetQueryFormParams) {
+func (t *testServer) GetQueryForm(w http.ResponseWriter, r *http.Request, params GetQueryFormParams) *Response {
 	t.queryParams = &params
 	if params.Ea != nil {
 		t.array = params.Ea
@@ -153,10 +171,11 @@ func (t *testServer) GetQueryForm(w http.ResponseWriter, r *http.Request, params
 	if params.N1s != nil {
 		t.n1param = params.N1s
 	}
+	return nil
 }
 
 //  (GET /header)
-func (t *testServer) GetHeader(w http.ResponseWriter, r *http.Request, params GetHeaderParams) {
+func (t *testServer) GetHeader(w http.ResponseWriter, r *http.Request, params GetHeaderParams) *Response {
 	t.headerParams = &params
 	if params.XPrimitive != nil {
 		t.primitive = params.XPrimitive
@@ -182,10 +201,11 @@ func (t *testServer) GetHeader(w http.ResponseWriter, r *http.Request, params Ge
 	if params.N1StartingWithNumber != nil {
 		t.n1param = params.N1StartingWithNumber
 	}
+	return nil
 }
 
 //  (GET /cookie)
-func (t *testServer) GetCookie(w http.ResponseWriter, r *http.Request, params GetCookieParams) {
+func (t *testServer) GetCookie(w http.ResponseWriter, r *http.Request, params GetCookieParams) *Response {
 	t.cookieParams = &params
 	if params.Ea != nil {
 		t.array = params.Ea
@@ -211,6 +231,7 @@ func (t *testServer) GetCookie(w http.ResponseWriter, r *http.Request, params Ge
 	if params.N1s != nil {
 		t.n1param = params.N1s
 	}
+	return nil
 }
 
 func TestParameterBinding(t *testing.T) {

--- a/internal/test/schemas/schemas.gen.go
+++ b/internal/test/schemas/schemas.gen.go
@@ -235,28 +235,28 @@ func GetIssues375JSON200Response(body EnumInObjInArray) *Response {
 type ServerInterface interface {
 
 	// (GET /ensure-everything-is-referenced)
-	EnsureEverythingIsReferenced(w http.ResponseWriter, r *http.Request)
+	EnsureEverythingIsReferenced(w http.ResponseWriter, r *http.Request) *Response
 
 	// (GET /issues/127)
-	Issue127(w http.ResponseWriter, r *http.Request)
+	Issue127(w http.ResponseWriter, r *http.Request) *Response
 
 	// (GET /issues/185)
-	Issue185(w http.ResponseWriter, r *http.Request)
+	Issue185(w http.ResponseWriter, r *http.Request) *Response
 
 	// (GET /issues/209/${str})
-	Issue209(w http.ResponseWriter, r *http.Request, str StringInPath)
+	Issue209(w http.ResponseWriter, r *http.Request, str StringInPath) *Response
 
 	// (GET /issues/30/{fallthrough})
-	Issue30(w http.ResponseWriter, r *http.Request, pFallthrough string)
+	Issue30(w http.ResponseWriter, r *http.Request, pFallthrough string) *Response
 
 	// (GET /issues/375)
-	GetIssues375(w http.ResponseWriter, r *http.Request)
+	GetIssues375(w http.ResponseWriter, r *http.Request) *Response
 
 	// (GET /issues/41/{1param})
-	Issue41(w http.ResponseWriter, r *http.Request, n1param N5startsWithNumber)
+	Issue41(w http.ResponseWriter, r *http.Request, n1param N5startsWithNumber) *Response
 
 	// (GET /issues/9)
-	Issue9(w http.ResponseWriter, r *http.Request, params Issue9Params)
+	Issue9(w http.ResponseWriter, r *http.Request, params Issue9Params) *Response
 }
 
 // ServerInterfaceWrapper converts contexts to parameters.
@@ -273,7 +273,10 @@ func (siw *ServerInterfaceWrapper) EnsureEverythingIsReferenced(w http.ResponseW
 	ctx = context.WithValue(ctx, AccessTokenScopes, []string{""})
 
 	var handler = http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-		siw.Handler.EnsureEverythingIsReferenced(w, r)
+		resp := siw.Handler.EnsureEverythingIsReferenced(w, r)
+		if resp != nil {
+			render.Render(w, r, resp)
+		}
 	})
 
 	handler(w, r.WithContext(ctx))
@@ -286,7 +289,10 @@ func (siw *ServerInterfaceWrapper) Issue127(w http.ResponseWriter, r *http.Reque
 	ctx = context.WithValue(ctx, AccessTokenScopes, []string{""})
 
 	var handler = http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-		siw.Handler.Issue127(w, r)
+		resp := siw.Handler.Issue127(w, r)
+		if resp != nil {
+			render.Render(w, r, resp)
+		}
 	})
 
 	handler(w, r.WithContext(ctx))
@@ -299,7 +305,10 @@ func (siw *ServerInterfaceWrapper) Issue185(w http.ResponseWriter, r *http.Reque
 	ctx = context.WithValue(ctx, AccessTokenScopes, []string{""})
 
 	var handler = http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-		siw.Handler.Issue185(w, r)
+		resp := siw.Handler.Issue185(w, r)
+		if resp != nil {
+			render.Render(w, r, resp)
+		}
 	})
 
 	handler(w, r.WithContext(ctx))
@@ -321,7 +330,10 @@ func (siw *ServerInterfaceWrapper) Issue209(w http.ResponseWriter, r *http.Reque
 	ctx = context.WithValue(ctx, AccessTokenScopes, []string{""})
 
 	var handler = http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-		siw.Handler.Issue209(w, r, str)
+		resp := siw.Handler.Issue209(w, r, str)
+		if resp != nil {
+			render.Render(w, r, resp)
+		}
 	})
 
 	handler(w, r.WithContext(ctx))
@@ -343,7 +355,10 @@ func (siw *ServerInterfaceWrapper) Issue30(w http.ResponseWriter, r *http.Reques
 	ctx = context.WithValue(ctx, AccessTokenScopes, []string{""})
 
 	var handler = http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-		siw.Handler.Issue30(w, r, pFallthrough)
+		resp := siw.Handler.Issue30(w, r, pFallthrough)
+		if resp != nil {
+			render.Render(w, r, resp)
+		}
 	})
 
 	handler(w, r.WithContext(ctx))
@@ -356,7 +371,10 @@ func (siw *ServerInterfaceWrapper) GetIssues375(w http.ResponseWriter, r *http.R
 	ctx = context.WithValue(ctx, AccessTokenScopes, []string{""})
 
 	var handler = http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-		siw.Handler.GetIssues375(w, r)
+		resp := siw.Handler.GetIssues375(w, r)
+		if resp != nil {
+			render.Render(w, r, resp)
+		}
 	})
 
 	handler(w, r.WithContext(ctx))
@@ -378,7 +396,10 @@ func (siw *ServerInterfaceWrapper) Issue41(w http.ResponseWriter, r *http.Reques
 	ctx = context.WithValue(ctx, AccessTokenScopes, []string{""})
 
 	var handler = http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-		siw.Handler.Issue41(w, r, n1param)
+		resp := siw.Handler.Issue41(w, r, n1param)
+		if resp != nil {
+			render.Render(w, r, resp)
+		}
 	})
 
 	handler(w, r.WithContext(ctx))
@@ -402,7 +423,10 @@ func (siw *ServerInterfaceWrapper) Issue9(w http.ResponseWriter, r *http.Request
 	}
 
 	var handler = http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-		siw.Handler.Issue9(w, r, params)
+		resp := siw.Handler.Issue9(w, r, params)
+		if resp != nil {
+			render.Render(w, r, resp)
+		}
 	})
 
 	handler(w, r.WithContext(ctx))

--- a/internal/test/server/server.gen.go
+++ b/internal/test/server/server.gen.go
@@ -323,41 +323,41 @@ func PostWithTaggedMiddlewareJSON200Response(body struct {
 type ServerInterface interface {
 	// get every type optional
 	// (GET /every-type-optional)
-	GetEveryTypeOptional(w http.ResponseWriter, r *http.Request)
+	GetEveryTypeOptional(w http.ResponseWriter, r *http.Request) *Response
 	// Get resource via simple path
 	// (GET /get-simple)
-	GetSimple(w http.ResponseWriter, r *http.Request)
+	GetSimple(w http.ResponseWriter, r *http.Request) *Response
 	// Getter with referenced parameter and referenced response
 	// (GET /get-with-args)
-	GetWithArgs(w http.ResponseWriter, r *http.Request, params GetWithArgsParams)
+	GetWithArgs(w http.ResponseWriter, r *http.Request, params GetWithArgsParams) *Response
 	// Getter with referenced parameter and referenced response
 	// (GET /get-with-references/{global_argument}/{argument})
-	GetWithReferences(w http.ResponseWriter, r *http.Request, globalArgument int64, argument Argument)
+	GetWithReferences(w http.ResponseWriter, r *http.Request, globalArgument int64, argument Argument) *Response
 	// Get an object by ID
 	// (GET /get-with-type/{content_type})
-	GetWithContentType(w http.ResponseWriter, r *http.Request, contentType GetWithContentTypeParamsContentType)
+	GetWithContentType(w http.ResponseWriter, r *http.Request, contentType GetWithContentTypeParamsContentType) *Response
 	// get with reserved keyword
 	// (GET /reserved-keyword)
-	GetReservedKeyword(w http.ResponseWriter, r *http.Request)
+	GetReservedKeyword(w http.ResponseWriter, r *http.Request) *Response
 	// Create a resource
 	// (POST /resource/{argument})
-	CreateResource(w http.ResponseWriter, r *http.Request, argument Argument)
+	CreateResource(w http.ResponseWriter, r *http.Request, argument Argument) *Response
 	// Create a resource with inline parameter
 	// (POST /resource2/{inline_argument})
-	CreateResource2(w http.ResponseWriter, r *http.Request, inlineArgument int, params CreateResource2Params)
+	CreateResource2(w http.ResponseWriter, r *http.Request, inlineArgument int, params CreateResource2Params) *Response
 	// Update a resource with inline body. The parameter name is a reserved
 	// keyword, so make sure that gets prefixed to avoid syntax errors
 	// (PUT /resource3/{fallthrough})
-	UpdateResource3(w http.ResponseWriter, r *http.Request, pFallthrough int)
+	UpdateResource3(w http.ResponseWriter, r *http.Request, pFallthrough int) *Response
 	// get response with reference
 	// (GET /response-with-reference)
-	GetResponseWithReference(w http.ResponseWriter, r *http.Request)
+	GetResponseWithReference(w http.ResponseWriter, r *http.Request) *Response
 
 	// (GET /with-tagged-middleware)
-	GetWithTaggedMiddleware(w http.ResponseWriter, r *http.Request)
+	GetWithTaggedMiddleware(w http.ResponseWriter, r *http.Request) *Response
 
 	// (POST /with-tagged-middleware)
-	PostWithTaggedMiddleware(w http.ResponseWriter, r *http.Request)
+	PostWithTaggedMiddleware(w http.ResponseWriter, r *http.Request) *Response
 }
 
 // ServerInterfaceWrapper converts contexts to parameters.
@@ -372,7 +372,10 @@ func (siw *ServerInterfaceWrapper) GetEveryTypeOptional(w http.ResponseWriter, r
 	ctx := r.Context()
 
 	var handler = http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-		siw.Handler.GetEveryTypeOptional(w, r)
+		resp := siw.Handler.GetEveryTypeOptional(w, r)
+		if resp != nil {
+			render.Render(w, r, resp)
+		}
 	})
 
 	handler(w, r.WithContext(ctx))
@@ -383,7 +386,10 @@ func (siw *ServerInterfaceWrapper) GetSimple(w http.ResponseWriter, r *http.Requ
 	ctx := r.Context()
 
 	var handler = http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-		siw.Handler.GetSimple(w, r)
+		resp := siw.Handler.GetSimple(w, r)
+		if resp != nil {
+			render.Render(w, r, resp)
+		}
 	})
 
 	handler(w, r.WithContext(ctx))
@@ -435,7 +441,10 @@ func (siw *ServerInterfaceWrapper) GetWithArgs(w http.ResponseWriter, r *http.Re
 	}
 
 	var handler = http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-		siw.Handler.GetWithArgs(w, r, params)
+		resp := siw.Handler.GetWithArgs(w, r, params)
+		if resp != nil {
+			render.Render(w, r, resp)
+		}
 	})
 
 	handler(w, r.WithContext(ctx))
@@ -464,7 +473,10 @@ func (siw *ServerInterfaceWrapper) GetWithReferences(w http.ResponseWriter, r *h
 	}
 
 	var handler = http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-		siw.Handler.GetWithReferences(w, r, globalArgument, argument)
+		resp := siw.Handler.GetWithReferences(w, r, globalArgument, argument)
+		if resp != nil {
+			render.Render(w, r, resp)
+		}
 	})
 
 	handler(w, r.WithContext(ctx))
@@ -484,7 +496,10 @@ func (siw *ServerInterfaceWrapper) GetWithContentType(w http.ResponseWriter, r *
 	}
 
 	var handler = http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-		siw.Handler.GetWithContentType(w, r, contentType)
+		resp := siw.Handler.GetWithContentType(w, r, contentType)
+		if resp != nil {
+			render.Render(w, r, resp)
+		}
 	})
 
 	handler(w, r.WithContext(ctx))
@@ -495,7 +510,10 @@ func (siw *ServerInterfaceWrapper) GetReservedKeyword(w http.ResponseWriter, r *
 	ctx := r.Context()
 
 	var handler = http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-		siw.Handler.GetReservedKeyword(w, r)
+		resp := siw.Handler.GetReservedKeyword(w, r)
+		if resp != nil {
+			render.Render(w, r, resp)
+		}
 	})
 
 	handler(w, r.WithContext(ctx))
@@ -515,7 +533,10 @@ func (siw *ServerInterfaceWrapper) CreateResource(w http.ResponseWriter, r *http
 	}
 
 	var handler = http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-		siw.Handler.CreateResource(w, r, argument)
+		resp := siw.Handler.CreateResource(w, r, argument)
+		if resp != nil {
+			render.Render(w, r, resp)
+		}
 	})
 
 	handler(w, r.WithContext(ctx))
@@ -546,7 +567,10 @@ func (siw *ServerInterfaceWrapper) CreateResource2(w http.ResponseWriter, r *htt
 	}
 
 	var handler = http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-		siw.Handler.CreateResource2(w, r, inlineArgument, params)
+		resp := siw.Handler.CreateResource2(w, r, inlineArgument, params)
+		if resp != nil {
+			render.Render(w, r, resp)
+		}
 	})
 
 	handler(w, r.WithContext(ctx))
@@ -566,7 +590,10 @@ func (siw *ServerInterfaceWrapper) UpdateResource3(w http.ResponseWriter, r *htt
 	}
 
 	var handler = http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-		siw.Handler.UpdateResource3(w, r, pFallthrough)
+		resp := siw.Handler.UpdateResource3(w, r, pFallthrough)
+		if resp != nil {
+			render.Render(w, r, resp)
+		}
 	})
 
 	handler(w, r.WithContext(ctx))
@@ -577,7 +604,10 @@ func (siw *ServerInterfaceWrapper) GetResponseWithReference(w http.ResponseWrite
 	ctx := r.Context()
 
 	var handler = http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-		siw.Handler.GetResponseWithReference(w, r)
+		resp := siw.Handler.GetResponseWithReference(w, r)
+		if resp != nil {
+			render.Render(w, r, resp)
+		}
 	})
 
 	handler(w, r.WithContext(ctx))
@@ -588,7 +618,10 @@ func (siw *ServerInterfaceWrapper) GetWithTaggedMiddleware(w http.ResponseWriter
 	ctx := r.Context()
 
 	var handler = http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-		siw.Handler.GetWithTaggedMiddleware(w, r)
+		resp := siw.Handler.GetWithTaggedMiddleware(w, r)
+		if resp != nil {
+			render.Render(w, r, resp)
+		}
 	})
 
 	// Operation specific middleware
@@ -602,7 +635,10 @@ func (siw *ServerInterfaceWrapper) PostWithTaggedMiddleware(w http.ResponseWrite
 	ctx := r.Context()
 
 	var handler = http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-		siw.Handler.PostWithTaggedMiddleware(w, r)
+		resp := siw.Handler.PostWithTaggedMiddleware(w, r)
+		if resp != nil {
+			render.Render(w, r, resp)
+		}
 	})
 
 	// Operation specific middleware

--- a/internal/test/server/server_moq.gen.go
+++ b/internal/test/server/server_moq.gen.go
@@ -18,40 +18,40 @@ var _ ServerInterface = &ServerInterfaceMock{}
 //
 // 		// make and configure a mocked ServerInterface
 // 		mockedServerInterface := &ServerInterfaceMock{
-// 			CreateResourceFunc: func(w http.ResponseWriter, r *http.Request, argument Argument)  {
+// 			CreateResourceFunc: func(w http.ResponseWriter, r *http.Request, argument Argument) *Response {
 // 				panic("mock out the CreateResource method")
 // 			},
-// 			CreateResource2Func: func(w http.ResponseWriter, r *http.Request, inlineArgument int, params CreateResource2Params)  {
+// 			CreateResource2Func: func(w http.ResponseWriter, r *http.Request, inlineArgument int, params CreateResource2Params) *Response {
 // 				panic("mock out the CreateResource2 method")
 // 			},
-// 			GetEveryTypeOptionalFunc: func(w http.ResponseWriter, r *http.Request)  {
+// 			GetEveryTypeOptionalFunc: func(w http.ResponseWriter, r *http.Request) *Response {
 // 				panic("mock out the GetEveryTypeOptional method")
 // 			},
-// 			GetReservedKeywordFunc: func(w http.ResponseWriter, r *http.Request)  {
+// 			GetReservedKeywordFunc: func(w http.ResponseWriter, r *http.Request) *Response {
 // 				panic("mock out the GetReservedKeyword method")
 // 			},
-// 			GetResponseWithReferenceFunc: func(w http.ResponseWriter, r *http.Request)  {
+// 			GetResponseWithReferenceFunc: func(w http.ResponseWriter, r *http.Request) *Response {
 // 				panic("mock out the GetResponseWithReference method")
 // 			},
-// 			GetSimpleFunc: func(w http.ResponseWriter, r *http.Request)  {
+// 			GetSimpleFunc: func(w http.ResponseWriter, r *http.Request) *Response {
 // 				panic("mock out the GetSimple method")
 // 			},
-// 			GetWithArgsFunc: func(w http.ResponseWriter, r *http.Request, params GetWithArgsParams)  {
+// 			GetWithArgsFunc: func(w http.ResponseWriter, r *http.Request, params GetWithArgsParams) *Response {
 // 				panic("mock out the GetWithArgs method")
 // 			},
-// 			GetWithContentTypeFunc: func(w http.ResponseWriter, r *http.Request, contentType GetWithContentTypeParamsContentType)  {
+// 			GetWithContentTypeFunc: func(w http.ResponseWriter, r *http.Request, contentType GetWithContentTypeParamsContentType) *Response {
 // 				panic("mock out the GetWithContentType method")
 // 			},
-// 			GetWithReferencesFunc: func(w http.ResponseWriter, r *http.Request, globalArgument int64, argument Argument)  {
+// 			GetWithReferencesFunc: func(w http.ResponseWriter, r *http.Request, globalArgument int64, argument Argument) *Response {
 // 				panic("mock out the GetWithReferences method")
 // 			},
-// 			GetWithTaggedMiddlewareFunc: func(w http.ResponseWriter, r *http.Request)  {
+// 			GetWithTaggedMiddlewareFunc: func(w http.ResponseWriter, r *http.Request) *Response {
 // 				panic("mock out the GetWithTaggedMiddleware method")
 // 			},
-// 			PostWithTaggedMiddlewareFunc: func(w http.ResponseWriter, r *http.Request)  {
+// 			PostWithTaggedMiddlewareFunc: func(w http.ResponseWriter, r *http.Request) *Response {
 // 				panic("mock out the PostWithTaggedMiddleware method")
 // 			},
-// 			UpdateResource3Func: func(w http.ResponseWriter, r *http.Request, pFallthrough int)  {
+// 			UpdateResource3Func: func(w http.ResponseWriter, r *http.Request, pFallthrough int) *Response {
 // 				panic("mock out the UpdateResource3 method")
 // 			},
 // 		}
@@ -62,40 +62,40 @@ var _ ServerInterface = &ServerInterfaceMock{}
 // 	}
 type ServerInterfaceMock struct {
 	// CreateResourceFunc mocks the CreateResource method.
-	CreateResourceFunc func(w http.ResponseWriter, r *http.Request, argument Argument)
+	CreateResourceFunc func(w http.ResponseWriter, r *http.Request, argument Argument) *Response
 
 	// CreateResource2Func mocks the CreateResource2 method.
-	CreateResource2Func func(w http.ResponseWriter, r *http.Request, inlineArgument int, params CreateResource2Params)
+	CreateResource2Func func(w http.ResponseWriter, r *http.Request, inlineArgument int, params CreateResource2Params) *Response
 
 	// GetEveryTypeOptionalFunc mocks the GetEveryTypeOptional method.
-	GetEveryTypeOptionalFunc func(w http.ResponseWriter, r *http.Request)
+	GetEveryTypeOptionalFunc func(w http.ResponseWriter, r *http.Request) *Response
 
 	// GetReservedKeywordFunc mocks the GetReservedKeyword method.
-	GetReservedKeywordFunc func(w http.ResponseWriter, r *http.Request)
+	GetReservedKeywordFunc func(w http.ResponseWriter, r *http.Request) *Response
 
 	// GetResponseWithReferenceFunc mocks the GetResponseWithReference method.
-	GetResponseWithReferenceFunc func(w http.ResponseWriter, r *http.Request)
+	GetResponseWithReferenceFunc func(w http.ResponseWriter, r *http.Request) *Response
 
 	// GetSimpleFunc mocks the GetSimple method.
-	GetSimpleFunc func(w http.ResponseWriter, r *http.Request)
+	GetSimpleFunc func(w http.ResponseWriter, r *http.Request) *Response
 
 	// GetWithArgsFunc mocks the GetWithArgs method.
-	GetWithArgsFunc func(w http.ResponseWriter, r *http.Request, params GetWithArgsParams)
+	GetWithArgsFunc func(w http.ResponseWriter, r *http.Request, params GetWithArgsParams) *Response
 
 	// GetWithContentTypeFunc mocks the GetWithContentType method.
-	GetWithContentTypeFunc func(w http.ResponseWriter, r *http.Request, contentType GetWithContentTypeParamsContentType)
+	GetWithContentTypeFunc func(w http.ResponseWriter, r *http.Request, contentType GetWithContentTypeParamsContentType) *Response
 
 	// GetWithReferencesFunc mocks the GetWithReferences method.
-	GetWithReferencesFunc func(w http.ResponseWriter, r *http.Request, globalArgument int64, argument Argument)
+	GetWithReferencesFunc func(w http.ResponseWriter, r *http.Request, globalArgument int64, argument Argument) *Response
 
 	// GetWithTaggedMiddlewareFunc mocks the GetWithTaggedMiddleware method.
-	GetWithTaggedMiddlewareFunc func(w http.ResponseWriter, r *http.Request)
+	GetWithTaggedMiddlewareFunc func(w http.ResponseWriter, r *http.Request) *Response
 
 	// PostWithTaggedMiddlewareFunc mocks the PostWithTaggedMiddleware method.
-	PostWithTaggedMiddlewareFunc func(w http.ResponseWriter, r *http.Request)
+	PostWithTaggedMiddlewareFunc func(w http.ResponseWriter, r *http.Request) *Response
 
 	// UpdateResource3Func mocks the UpdateResource3 method.
-	UpdateResource3Func func(w http.ResponseWriter, r *http.Request, pFallthrough int)
+	UpdateResource3Func func(w http.ResponseWriter, r *http.Request, pFallthrough int) *Response
 
 	// calls tracks calls to the methods.
 	calls struct {
@@ -215,7 +215,7 @@ type ServerInterfaceMock struct {
 }
 
 // CreateResource calls CreateResourceFunc.
-func (mock *ServerInterfaceMock) CreateResource(w http.ResponseWriter, r *http.Request, argument Argument) {
+func (mock *ServerInterfaceMock) CreateResource(w http.ResponseWriter, r *http.Request, argument Argument) *Response {
 	if mock.CreateResourceFunc == nil {
 		panic("ServerInterfaceMock.CreateResourceFunc: method is nil but ServerInterface.CreateResource was just called")
 	}
@@ -231,7 +231,7 @@ func (mock *ServerInterfaceMock) CreateResource(w http.ResponseWriter, r *http.R
 	mock.lockCreateResource.Lock()
 	mock.calls.CreateResource = append(mock.calls.CreateResource, callInfo)
 	mock.lockCreateResource.Unlock()
-	mock.CreateResourceFunc(w, r, argument)
+	return mock.CreateResourceFunc(w, r, argument)
 }
 
 // CreateResourceCalls gets all the calls that were made to CreateResource.
@@ -254,7 +254,7 @@ func (mock *ServerInterfaceMock) CreateResourceCalls() []struct {
 }
 
 // CreateResource2 calls CreateResource2Func.
-func (mock *ServerInterfaceMock) CreateResource2(w http.ResponseWriter, r *http.Request, inlineArgument int, params CreateResource2Params) {
+func (mock *ServerInterfaceMock) CreateResource2(w http.ResponseWriter, r *http.Request, inlineArgument int, params CreateResource2Params) *Response {
 	if mock.CreateResource2Func == nil {
 		panic("ServerInterfaceMock.CreateResource2Func: method is nil but ServerInterface.CreateResource2 was just called")
 	}
@@ -272,7 +272,7 @@ func (mock *ServerInterfaceMock) CreateResource2(w http.ResponseWriter, r *http.
 	mock.lockCreateResource2.Lock()
 	mock.calls.CreateResource2 = append(mock.calls.CreateResource2, callInfo)
 	mock.lockCreateResource2.Unlock()
-	mock.CreateResource2Func(w, r, inlineArgument, params)
+	return mock.CreateResource2Func(w, r, inlineArgument, params)
 }
 
 // CreateResource2Calls gets all the calls that were made to CreateResource2.
@@ -297,7 +297,7 @@ func (mock *ServerInterfaceMock) CreateResource2Calls() []struct {
 }
 
 // GetEveryTypeOptional calls GetEveryTypeOptionalFunc.
-func (mock *ServerInterfaceMock) GetEveryTypeOptional(w http.ResponseWriter, r *http.Request) {
+func (mock *ServerInterfaceMock) GetEveryTypeOptional(w http.ResponseWriter, r *http.Request) *Response {
 	if mock.GetEveryTypeOptionalFunc == nil {
 		panic("ServerInterfaceMock.GetEveryTypeOptionalFunc: method is nil but ServerInterface.GetEveryTypeOptional was just called")
 	}
@@ -311,7 +311,7 @@ func (mock *ServerInterfaceMock) GetEveryTypeOptional(w http.ResponseWriter, r *
 	mock.lockGetEveryTypeOptional.Lock()
 	mock.calls.GetEveryTypeOptional = append(mock.calls.GetEveryTypeOptional, callInfo)
 	mock.lockGetEveryTypeOptional.Unlock()
-	mock.GetEveryTypeOptionalFunc(w, r)
+	return mock.GetEveryTypeOptionalFunc(w, r)
 }
 
 // GetEveryTypeOptionalCalls gets all the calls that were made to GetEveryTypeOptional.
@@ -332,7 +332,7 @@ func (mock *ServerInterfaceMock) GetEveryTypeOptionalCalls() []struct {
 }
 
 // GetReservedKeyword calls GetReservedKeywordFunc.
-func (mock *ServerInterfaceMock) GetReservedKeyword(w http.ResponseWriter, r *http.Request) {
+func (mock *ServerInterfaceMock) GetReservedKeyword(w http.ResponseWriter, r *http.Request) *Response {
 	if mock.GetReservedKeywordFunc == nil {
 		panic("ServerInterfaceMock.GetReservedKeywordFunc: method is nil but ServerInterface.GetReservedKeyword was just called")
 	}
@@ -346,7 +346,7 @@ func (mock *ServerInterfaceMock) GetReservedKeyword(w http.ResponseWriter, r *ht
 	mock.lockGetReservedKeyword.Lock()
 	mock.calls.GetReservedKeyword = append(mock.calls.GetReservedKeyword, callInfo)
 	mock.lockGetReservedKeyword.Unlock()
-	mock.GetReservedKeywordFunc(w, r)
+	return mock.GetReservedKeywordFunc(w, r)
 }
 
 // GetReservedKeywordCalls gets all the calls that were made to GetReservedKeyword.
@@ -367,7 +367,7 @@ func (mock *ServerInterfaceMock) GetReservedKeywordCalls() []struct {
 }
 
 // GetResponseWithReference calls GetResponseWithReferenceFunc.
-func (mock *ServerInterfaceMock) GetResponseWithReference(w http.ResponseWriter, r *http.Request) {
+func (mock *ServerInterfaceMock) GetResponseWithReference(w http.ResponseWriter, r *http.Request) *Response {
 	if mock.GetResponseWithReferenceFunc == nil {
 		panic("ServerInterfaceMock.GetResponseWithReferenceFunc: method is nil but ServerInterface.GetResponseWithReference was just called")
 	}
@@ -381,7 +381,7 @@ func (mock *ServerInterfaceMock) GetResponseWithReference(w http.ResponseWriter,
 	mock.lockGetResponseWithReference.Lock()
 	mock.calls.GetResponseWithReference = append(mock.calls.GetResponseWithReference, callInfo)
 	mock.lockGetResponseWithReference.Unlock()
-	mock.GetResponseWithReferenceFunc(w, r)
+	return mock.GetResponseWithReferenceFunc(w, r)
 }
 
 // GetResponseWithReferenceCalls gets all the calls that were made to GetResponseWithReference.
@@ -402,7 +402,7 @@ func (mock *ServerInterfaceMock) GetResponseWithReferenceCalls() []struct {
 }
 
 // GetSimple calls GetSimpleFunc.
-func (mock *ServerInterfaceMock) GetSimple(w http.ResponseWriter, r *http.Request) {
+func (mock *ServerInterfaceMock) GetSimple(w http.ResponseWriter, r *http.Request) *Response {
 	if mock.GetSimpleFunc == nil {
 		panic("ServerInterfaceMock.GetSimpleFunc: method is nil but ServerInterface.GetSimple was just called")
 	}
@@ -416,7 +416,7 @@ func (mock *ServerInterfaceMock) GetSimple(w http.ResponseWriter, r *http.Reques
 	mock.lockGetSimple.Lock()
 	mock.calls.GetSimple = append(mock.calls.GetSimple, callInfo)
 	mock.lockGetSimple.Unlock()
-	mock.GetSimpleFunc(w, r)
+	return mock.GetSimpleFunc(w, r)
 }
 
 // GetSimpleCalls gets all the calls that were made to GetSimple.
@@ -437,7 +437,7 @@ func (mock *ServerInterfaceMock) GetSimpleCalls() []struct {
 }
 
 // GetWithArgs calls GetWithArgsFunc.
-func (mock *ServerInterfaceMock) GetWithArgs(w http.ResponseWriter, r *http.Request, params GetWithArgsParams) {
+func (mock *ServerInterfaceMock) GetWithArgs(w http.ResponseWriter, r *http.Request, params GetWithArgsParams) *Response {
 	if mock.GetWithArgsFunc == nil {
 		panic("ServerInterfaceMock.GetWithArgsFunc: method is nil but ServerInterface.GetWithArgs was just called")
 	}
@@ -453,7 +453,7 @@ func (mock *ServerInterfaceMock) GetWithArgs(w http.ResponseWriter, r *http.Requ
 	mock.lockGetWithArgs.Lock()
 	mock.calls.GetWithArgs = append(mock.calls.GetWithArgs, callInfo)
 	mock.lockGetWithArgs.Unlock()
-	mock.GetWithArgsFunc(w, r, params)
+	return mock.GetWithArgsFunc(w, r, params)
 }
 
 // GetWithArgsCalls gets all the calls that were made to GetWithArgs.
@@ -476,7 +476,7 @@ func (mock *ServerInterfaceMock) GetWithArgsCalls() []struct {
 }
 
 // GetWithContentType calls GetWithContentTypeFunc.
-func (mock *ServerInterfaceMock) GetWithContentType(w http.ResponseWriter, r *http.Request, contentType GetWithContentTypeParamsContentType) {
+func (mock *ServerInterfaceMock) GetWithContentType(w http.ResponseWriter, r *http.Request, contentType GetWithContentTypeParamsContentType) *Response {
 	if mock.GetWithContentTypeFunc == nil {
 		panic("ServerInterfaceMock.GetWithContentTypeFunc: method is nil but ServerInterface.GetWithContentType was just called")
 	}
@@ -492,7 +492,7 @@ func (mock *ServerInterfaceMock) GetWithContentType(w http.ResponseWriter, r *ht
 	mock.lockGetWithContentType.Lock()
 	mock.calls.GetWithContentType = append(mock.calls.GetWithContentType, callInfo)
 	mock.lockGetWithContentType.Unlock()
-	mock.GetWithContentTypeFunc(w, r, contentType)
+	return mock.GetWithContentTypeFunc(w, r, contentType)
 }
 
 // GetWithContentTypeCalls gets all the calls that were made to GetWithContentType.
@@ -515,7 +515,7 @@ func (mock *ServerInterfaceMock) GetWithContentTypeCalls() []struct {
 }
 
 // GetWithReferences calls GetWithReferencesFunc.
-func (mock *ServerInterfaceMock) GetWithReferences(w http.ResponseWriter, r *http.Request, globalArgument int64, argument Argument) {
+func (mock *ServerInterfaceMock) GetWithReferences(w http.ResponseWriter, r *http.Request, globalArgument int64, argument Argument) *Response {
 	if mock.GetWithReferencesFunc == nil {
 		panic("ServerInterfaceMock.GetWithReferencesFunc: method is nil but ServerInterface.GetWithReferences was just called")
 	}
@@ -533,7 +533,7 @@ func (mock *ServerInterfaceMock) GetWithReferences(w http.ResponseWriter, r *htt
 	mock.lockGetWithReferences.Lock()
 	mock.calls.GetWithReferences = append(mock.calls.GetWithReferences, callInfo)
 	mock.lockGetWithReferences.Unlock()
-	mock.GetWithReferencesFunc(w, r, globalArgument, argument)
+	return mock.GetWithReferencesFunc(w, r, globalArgument, argument)
 }
 
 // GetWithReferencesCalls gets all the calls that were made to GetWithReferences.
@@ -558,7 +558,7 @@ func (mock *ServerInterfaceMock) GetWithReferencesCalls() []struct {
 }
 
 // GetWithTaggedMiddleware calls GetWithTaggedMiddlewareFunc.
-func (mock *ServerInterfaceMock) GetWithTaggedMiddleware(w http.ResponseWriter, r *http.Request) {
+func (mock *ServerInterfaceMock) GetWithTaggedMiddleware(w http.ResponseWriter, r *http.Request) *Response {
 	if mock.GetWithTaggedMiddlewareFunc == nil {
 		panic("ServerInterfaceMock.GetWithTaggedMiddlewareFunc: method is nil but ServerInterface.GetWithTaggedMiddleware was just called")
 	}
@@ -572,7 +572,7 @@ func (mock *ServerInterfaceMock) GetWithTaggedMiddleware(w http.ResponseWriter, 
 	mock.lockGetWithTaggedMiddleware.Lock()
 	mock.calls.GetWithTaggedMiddleware = append(mock.calls.GetWithTaggedMiddleware, callInfo)
 	mock.lockGetWithTaggedMiddleware.Unlock()
-	mock.GetWithTaggedMiddlewareFunc(w, r)
+	return mock.GetWithTaggedMiddlewareFunc(w, r)
 }
 
 // GetWithTaggedMiddlewareCalls gets all the calls that were made to GetWithTaggedMiddleware.
@@ -593,7 +593,7 @@ func (mock *ServerInterfaceMock) GetWithTaggedMiddlewareCalls() []struct {
 }
 
 // PostWithTaggedMiddleware calls PostWithTaggedMiddlewareFunc.
-func (mock *ServerInterfaceMock) PostWithTaggedMiddleware(w http.ResponseWriter, r *http.Request) {
+func (mock *ServerInterfaceMock) PostWithTaggedMiddleware(w http.ResponseWriter, r *http.Request) *Response {
 	if mock.PostWithTaggedMiddlewareFunc == nil {
 		panic("ServerInterfaceMock.PostWithTaggedMiddlewareFunc: method is nil but ServerInterface.PostWithTaggedMiddleware was just called")
 	}
@@ -607,7 +607,7 @@ func (mock *ServerInterfaceMock) PostWithTaggedMiddleware(w http.ResponseWriter,
 	mock.lockPostWithTaggedMiddleware.Lock()
 	mock.calls.PostWithTaggedMiddleware = append(mock.calls.PostWithTaggedMiddleware, callInfo)
 	mock.lockPostWithTaggedMiddleware.Unlock()
-	mock.PostWithTaggedMiddlewareFunc(w, r)
+	return mock.PostWithTaggedMiddlewareFunc(w, r)
 }
 
 // PostWithTaggedMiddlewareCalls gets all the calls that were made to PostWithTaggedMiddleware.
@@ -628,7 +628,7 @@ func (mock *ServerInterfaceMock) PostWithTaggedMiddlewareCalls() []struct {
 }
 
 // UpdateResource3 calls UpdateResource3Func.
-func (mock *ServerInterfaceMock) UpdateResource3(w http.ResponseWriter, r *http.Request, pFallthrough int) {
+func (mock *ServerInterfaceMock) UpdateResource3(w http.ResponseWriter, r *http.Request, pFallthrough int) *Response {
 	if mock.UpdateResource3Func == nil {
 		panic("ServerInterfaceMock.UpdateResource3Func: method is nil but ServerInterface.UpdateResource3 was just called")
 	}
@@ -644,7 +644,7 @@ func (mock *ServerInterfaceMock) UpdateResource3(w http.ResponseWriter, r *http.
 	mock.lockUpdateResource3.Lock()
 	mock.calls.UpdateResource3 = append(mock.calls.UpdateResource3, callInfo)
 	mock.lockUpdateResource3.Unlock()
-	mock.UpdateResource3Func(w, r, pFallthrough)
+	return mock.UpdateResource3Func(w, r, pFallthrough)
 }
 
 // UpdateResource3Calls gets all the calls that were made to UpdateResource3.

--- a/internal/test/server/server_test.go
+++ b/internal/test/server/server_test.go
@@ -18,9 +18,10 @@ var noopMiddlewares = map[string]func(http.Handler) http.Handler{
 func TestParameters(t *testing.T) {
 	m := ServerInterfaceMock{}
 
-	m.CreateResource2Func = func(w http.ResponseWriter, r *http.Request, inlineArgument int, params CreateResource2Params) {
+	m.CreateResource2Func = func(w http.ResponseWriter, r *http.Request, inlineArgument int, params CreateResource2Params) *Response {
 		assert.Equal(t, 99, *params.InlineQueryArgument)
 		assert.Equal(t, 1, inlineArgument)
+		return nil
 	}
 
 	h := Handler(&m, WithMiddlewares(noopMiddlewares))
@@ -65,7 +66,7 @@ func TestOmitMiddlewares(t *testing.T) {
 
 func TestMiddlewareCalled(t *testing.T) {
 	m := ServerInterfaceMock{}
-	m.GetWithTaggedMiddlewareFunc = func(w http.ResponseWriter, r *http.Request) {}
+	m.GetWithTaggedMiddlewareFunc = func(w http.ResponseWriter, r *http.Request) *Response { return nil }
 
 	called := false
 	mw := map[string]func(http.Handler) http.Handler{
@@ -88,7 +89,7 @@ func TestMiddlewareCalled(t *testing.T) {
 
 func TestMiddlewareCalledWithOrder(t *testing.T) {
 	m := ServerInterfaceMock{}
-	m.PostWithTaggedMiddlewareFunc = func(w http.ResponseWriter, r *http.Request) {}
+	m.PostWithTaggedMiddlewareFunc = func(w http.ResponseWriter, r *http.Request) *Response { return nil }
 
 	var order []string
 	mw := map[string]func(http.Handler) http.Handler{

--- a/pkg/codegen/templates/interface.tmpl
+++ b/pkg/codegen/templates/interface.tmpl
@@ -2,6 +2,6 @@
 type ServerInterface interface {
 	{{range .}}{{.SummaryAsComment }}
 	// ({{.Method}} {{.Path}})
-	{{.OperationID}}(w http.ResponseWriter, r *http.Request{{genParamArgs .PathParams}}{{if .RequiresParamObject}}, params {{.OperationID}}Params{{end}})
+	{{.OperationID}}(w http.ResponseWriter, r *http.Request{{genParamArgs .PathParams}}{{if .RequiresParamObject}}, params {{.OperationID}}Params{{end}}) *Response
 	{{end}}
 }

--- a/pkg/codegen/templates/middleware.tmpl
+++ b/pkg/codegen/templates/middleware.tmpl
@@ -164,7 +164,10 @@ func (siw *ServerInterfaceWrapper) {{$opid}}(w http.ResponseWriter, r *http.Requ
 	{{end}}
 
 	var handler = http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-		siw.Handler.{{.OperationID}}(w, r{{genParamNames .PathParams}}{{if .RequiresParamObject}}, params{{end}})
+		resp := siw.Handler.{{.OperationID}}(w, r{{genParamNames .PathParams}}{{if .RequiresParamObject}}, params{{end}})
+		if resp != nil {
+			render.Render(w, r, resp)
+		}
 	})
 
 	{{ with .Middlewares -}}


### PR DESCRIPTION
This commit changes the generated handler methods inside ServerInterface
to directly return a *Response value instead of requiring it to call
`render.Render` manually. This results in much cleaner handler code.

While this change breaks all existing code, it is not a significant
change by any means, so most changes can be regexed away to work.

As an example, `petstore`'s `FindPetByID` is now

```go
func (p *PetStore) FindPetByID(w http.ResponseWriter, r *http.Request, id int64) *Response {
	p.Lock.Lock()
	defer p.Lock.Unlock()

	pet, found := p.Pets[id]
	if !found {
		return FindPetByIDJSONDefaultResponse(Error{fmt.Sprintf(petNotFoundMsg, id)}).Status(http.StatusNotFound)
	}

	return FindPetByIDJSON200Response(pet)
}
```

compared to before

```go
func (p *PetStore) FindPetByID(w http.ResponseWriter, r *http.Request, id int64) {
	p.Lock.Lock()
	defer p.Lock.Unlock()

	pet, found := p.Pets[id]
	if !found {
		render.Render(
			w, r,
			FindPetByIDJSONDefaultResponse(Error{fmt.Sprintf(petNotFoundMsg, id)}).Status(http.StatusNotFound),
		)
		return
	}

	render.Render(w, r, FindPetByIDJSON200Response(pet))
}
```

Ideally, the above piece of code would look something like

```go
func (p *PetStore) FindPetByID(w http.ResponseWriter, r *http.Request, id int64) *Response {
	p.Lock.Lock()
	defer p.Lock.Unlock()

	pet, found := p.Pets[id]
	if !found {
		return FindPetByIDJSON404Response(Error{fmt.Sprintf(petNotFoundMsg, id)})
	}

	return FindPetByIDJSON200Response(pet)
}
```

where a `FindPetByIDJSON404Response` is properly generated by the OpenAPI schema having the 404 status code documented, but it isn't in the example schema for some reason.