### PR TITLE
Implement x-go-optional-value, x-go-string

### DIFF
--- a/README.md
+++ b/README.md
@@ -281,6 +281,35 @@ look through those tests for more usage examples.
   handler = siw.Middlewares["limit"](handler).ServeHTTP
   ```
 
+- `x-go-optional-value`: boolean, forces the generator to output value types (as
+  opposed to pointer nil-able types) for all optional fields. This is
+  particularly useful for when there is no practical difference between an empty
+  omitted `string` and an omitted nil `*string`.
+
+  This property can go in either the property value or the object attribute
+  itself:
+
+    ```yaml
+    components:
+	  schemas:
+	    Object:
+		  x-go-optional-value: true # valid
+		  properties:
+		    name:
+			  type: string
+			  x-go-optional-value: false # valid, overrides
+    ```
+
+- `x-go-string`: boolean, makes the generator add a `,string` attribute into the
+  JSON struct tag of an object's field. This is useful for sending large numbers
+  over JSON to JavaScript (or other dynamically-typed languages) where they
+  would be parsed to floats otherwise.
+
+- `x-go-omitempty`: boolean, makes the generator add a `,omitempty` attribute
+  into the JSON struct tag. Note that if a field doesn't appear in `required`,
+  then it will have an `omitempty` by default and its type will be a nil-able
+  pointer.
+
 ## Using `goapi-gen`
 
 [Usage details](docs.md)

--- a/internal/test/components/components.gen.go
+++ b/internal/test/components/components.gen.go
@@ -59,11 +59,31 @@ type AdditionalPropertiesObject5 struct {
 	AdditionalProperties map[string]SchemaObject `json:"-"`
 }
 
+// Tests x-go-string
+type GoStringTag struct {
+	ID   int    `json:"id,string"`
+	Name string `json:"name"`
+}
+
 // ObjectWithJSONField defines model for ObjectWithJsonField.
 type ObjectWithJSONField struct {
 	Name   string          `json:"name"`
 	Value1 json.RawMessage `json:"value1"`
 	Value2 json.RawMessage `json:"value2,omitempty"`
+}
+
+// Tests x-go-optional-value on the whole object
+type OptionalObject struct {
+	Str1    string  `json:"str1,omitempty"`
+	Str2    string  `json:"str2,omitempty"`
+	StrPtr1 *string `json:"str_ptr1,omitempty"`
+	StrPtr2 *string `json:"str_ptr2,omitempty"`
+}
+
+// Tests x-go-optional-value
+type OptionalValue struct {
+	Str1 string `json:"str1,omitempty"`
+	Str2 string `json:"str2,omitempty"`
 }
 
 // SchemaObject defines model for SchemaObject.
@@ -179,11 +199,20 @@ func EnsureEverythingIsReferencedJSON200Response(body struct {
 	Five *AdditionalPropertiesObject5 `json:"five,omitempty"`
 
 	// Has anonymous field which has additional properties
-	Four      *AdditionalPropertiesObject4 `json:"four,omitempty"`
-	JSONField *ObjectWithJSONField         `json:"jsonField,omitempty"`
+	Four *AdditionalPropertiesObject4 `json:"four,omitempty"`
+
+	// Tests x-go-string
+	GoStringTag *GoStringTag         `json:"goStringTag,omitempty"`
+	JSONField   *ObjectWithJSONField `json:"jsonField,omitempty"`
 
 	// Has additional properties of type int
 	One *AdditionalPropertiesObject1 `json:"one,omitempty"`
+
+	// Tests x-go-optional-value on the whole object
+	OptionalObject OptionalObject `json:"optionalObject,omitempty"`
+
+	// Tests x-go-optional-value
+	OptionalValue *OptionalValue `json:"optionalValue,omitempty"`
 
 	// Allows any additional property
 	Three *AdditionalPropertiesObject3 `json:"three,omitempty"`
@@ -994,23 +1023,25 @@ func WithErrorHandler(handler func(w http.ResponseWriter, r *http.Request, err e
 // Base64 encoded, gzipped, json marshaled Swagger object
 var swaggerSpec = []string{
 
-	"H4sIAAAAAAAC/9RXTW/jNhD9KwTboxLHzvaim4tu0RRoG+wG6GFjBLQ4ipjKQy05sldY6L8XQ8nflNdx",
-	"9rK5RJY5X49v3oy/yswuKouA5GX6VTr4XIOnX602EF582Lxo+GNmkQCJH1VVlSZTZCyOXrxFfuezAhaK",
-	"nypnK3DUe/ndQKn54WcHuUzlT6Nt2FFn5Ecfw/9/5i+QkWzbJCRjHGiZfuo9zPg1wRcaVaUyByGpqUCm",
-	"0pMz+Cxb/mMfvrLo18V0H/oYP1o9idTgM2cqzlGmciq8WVQliHWRwm6D9Vmwo6nWhk1Ueb+poktrHAqP",
-	"fL0T3yDBMzh5FP4P5cXWVmwREjYXbCwMkkwOoDM67hvVAiJVJ9JWXYAYJPuYBhcJR5gl66NrRJITKEyG",
-	"UchV6eGw8N8seIGWhCpLu4pj8Na6v1Npt8OlkauPKptyQV4obCJVNUc1vSL316X97nVpByaixWZhay9y",
-	"bi2xKkxWiGKIo8f3gwjuW2G/a/nnmXd5JZeg+Mup7j5fuc7v+5WhQnRORG6d0CYLh1wH+FHqXYR/DRV/",
-	"eosbUT0L5UQuVVlDULDcuoUimcqg28nA0ckZR+Nt10eKob8H1VHuuXGe/h4qwNnyDAKEU8mOq1kYBQZz",
-	"y8alyQA9bJGSf909sHcyxO7lA3gSH8EtA42W4Hx3jePrm+ubTmABVWVkKm+vb67H3BmKipD/CNDXDq5g",
-	"Ca6hwuDzlfFXDnJwgBmE23qGUPg+Rx4K4wWgrqxBEvDFePLCW0GFIrFlnMgUijmIzIEi0MKgoML4R/QV",
-	"ZEKhDjI7B1G5GkE/8o0xvmFK32mZyvchwfeb/O78h212yc4+0wyRfm/lGe3uO4frw+Tm5g07Q26W8K3G",
-	"O9XLbSJzW7vLXbxjFy+7jXbKT6w3mSz4hiLGgZeFgzf4uA0+VvZyD5PQYged3K9XuapLGmZKT4bRwSLZ",
-	"WY8q5dTCP7EKPimtn/j+/WCLTAW3WaeZwRIInA+kV2JuddOPsF4L4pIb6Yj7kAVf3FTr+5ACd/Q6gEw/",
-	"RZt1c2J4ZoZgvKXKzzW4Zj2UUlmN5a5mdbNy2wenJuqRoHpqgmx1q61sk3OyxZ3xHwbmZmfpQUQA7QVZ",
-	"MYdHpNphEBuyQvUnu4WVh1YsW7ZcWfffMAKTkwi8atWITIpDssZWhFnbzvYEC+uybBNZWR9hXxjiote+",
-	"XbqxuimD/K02DjKKApIwTx/xJPBM7JhthLMstweMdRf+8Dx/fTv3GnaW9Qt3uPX2vr6n9pAr7fHFtW37",
-	"fwAAAP//Xv36ip0PAAA=",
+	"H4sIAAAAAAAC/9RYT2/jthP9KgR/v6Mcx872oluKbtsUaBtsgvawCQJGHFncykMtScURFvruxVCyJduU",
+	"VnZy6V5Wljj/HmceH/ONJ3pdaAR0lsffuIGvJVj3o5YK/ItPuxcV/Uw0OkBHj6IocpUIpzTOv1iN9M4m",
+	"GawFPRVGF2Bc6+VnBbmkh/8bSHnM/zfvws4bIzu/8///+fwFEsfrOvLJKAOSx59bD4/02sGrmxe5UAch",
+	"XVUAj7l1RuGK1/SPfNhCo90W0/xoY/zX6om4BJsYVVCOPObXzKp1kQPbFsl0F6zNghxdS6nIROS3uyqa",
+	"tBa+8MDnXnyFDlZg+FH4X4VlnS3rEGI6ZWTMFDoeHUCnZNg3ijUEqo64LpoAIUj2MfUuIorwGG2XbhGJ",
+	"RlBYDqOQitzCYeE/abAMtWMiz/UmjMFb636n0q6GS3OmPKrsmgqyTGAVqKo6qumE3E9L+8NpaftORI3V",
+	"WpeWpTRabJOpJGPZUI8e7w8imO+Ffdfyp5k3eUXnoPjD2HRPZ67pc79RLmONE5Zqw6RK/CLTAH6U+i/6",
+	"zhd9L1aU0n6Ye7DOstfZSs9aaEZHaremb9Fum3/Vjd57jV0D0N/KZb9ZjbszYVKTRPxF5CV4Ak61WQvH",
+	"Y+6PnWhg6XLC0nD6baRgCS25difi4CZseXjm3TGNzGXANpnOd+fO4QZZZxbB2q0zy6EPT0XQqt3F/Sxa",
+	"gu4Mlyca1gNfqW968PzVvJ2MzkQkxoPbU8rxNnVgh/dm+ag7U2Ws+2OoRY3OJwyJXxX1XD16raIw1WSc",
+	"qwTQQjcL/Pebe/LulCP3HkV2B+bF89wLGNugu7i4vLhsFACgKBSP+dXF5cWCwBUu8/nPAW1pYAYvYCqX",
+	"KVzNlJ0ZSMEAJuDncQWhxs6UZYCy0Aodg1dFO2k1c5lwrKNElghkz8ASA8KBZIq6XtkHtAUkTKD0OuAZ",
+	"WGFKBPlAM0n4ehl5I3nMP/oEP+7yu7GfuuyinuCuhlh5T5PP+4L8UN8uLy/fIGpT9QLfOxnGDps64qku",
+	"zfkuPpCL1f6ZMOapf3zUkafEScI8xNvUZviG8hd9qdpN22ga+6t79ju6mWLeLKZ5ygy8oYIr72Ojz/ew",
+	"5AEGau8tqShzN9zhbRPPD25ojfW8EEas7RPJiych5RP1rR0c7WtG9NCIEW8JDoz1wyrYs5ZVqw1bDgtr",
+	"mcAk3/osqG2upbz1KRATbQPw+HOQZHYrhsWoD0bXP/61BFNt1V7MiwXvc22jZrr5HZOqRweBdZWn2+bO",
+	"yOtoSrbY09Veie4uAy2ICCAtc5o9wwO60qAnSaeZaFc2N0FSg6FsyXKjzT/DCCxHEThJwwdOuMNmDWnv",
+	"x7p+3CNaLPO8jnihbaD7vDpmLWf3241YWSikr1IZSFwQkIj69AFHgafGDtkGepaOiYOONWf+RWf6vWjq",
+	"NvRuwWdejrb6fLtP9WGv1McbV9f1vwEAAP//YqjbhPYSAAA=",
 }
 
 // GetSwagger returns the content of the embedded swagger specification file

--- a/internal/test/components/components.yaml
+++ b/internal/test/components/components.yaml
@@ -35,6 +35,12 @@ paths:
                     $ref: "#/components/schemas/AdditionalPropertiesObject5"
                   jsonField:
                     $ref: "#/components/schemas/ObjectWithJsonField"
+                  goStringTag:
+                    $ref: "#/components/schemas/GoStringTag"
+                  optionalValue:
+                    $ref: "#/components/schemas/OptionalValue"
+                  optionalObject:
+                    $ref: "#/components/schemas/OptionalObject"
         default:
           $ref: "#/components/responses/ResponseObject"
   /params_with_add_props:
@@ -95,6 +101,41 @@ components:
       required:
         - role
         - firstName
+    GoStringTag:
+      description: Tests x-go-string
+      type: object
+      properties:
+        name:
+          type: string
+        id:
+          type: string
+          x-go-type: int
+          x-go-string: true
+      required: [name, id]
+    OptionalValue:
+      description: Tests x-go-optional-value
+      type: object
+      properties:
+        str1:
+          type: string
+          x-go-optional-value: true
+        str2:
+          type: string
+          x-go-optional-value: true
+    OptionalObject:
+      description: Tests x-go-optional-value on the whole object
+      x-go-optional-value: true
+      properties:
+        str1:
+          type: string
+        str2:
+          type: string
+        str_ptr1:
+          type: string
+          x-go-optional-value: false
+        str_ptr2:
+          type: string
+          x-go-optional-value: false
     AdditionalPropertiesObject1:
       description: Has additional properties of type int
       type: object

--- a/internal/test/components/components_test.go
+++ b/internal/test/components/components_test.go
@@ -33,6 +33,29 @@ func TestRawJSON(t *testing.T) {
 
 }
 
+func TestGoStringTag(t *testing.T) {
+	buf := `{"id": "500", "name": "hi"}`
+	var dst GoStringTag
+	err := json.Unmarshal([]byte(buf), &dst)
+	assert.NoError(t, err)
+	assert.Equal(t, 500, dst.ID)
+	assert.Equal(t, "hi", dst.Name)
+}
+
+func TestOptionalValue(t *testing.T) {
+	src := OptionalValue{Str2: "hi"}
+	b, err := json.Marshal(src)
+	assert.NoError(t, err)
+	assert.Equal(t, string(b), `{"str2":"hi"}`)
+}
+
+func TestOptionalObject(t *testing.T) {
+	src := OptionalObject{Str2: "hi", StrPtr2: new(string)}
+	b, err := json.Marshal(src)
+	assert.NoError(t, err)
+	assert.Equal(t, string(b), `{"str2":"hi","str_ptr2":""}`)
+}
+
 func TestAdditionalProperties(t *testing.T) {
 	buf := `{"name": "bob", "id": 5, "optional":"yes", "additional": 42}`
 	var dst AdditionalPropertiesObject1

--- a/pkg/codegen/extension.go
+++ b/pkg/codegen/extension.go
@@ -6,59 +6,55 @@ import (
 )
 
 const (
-	extPropGoType    = "x-go-type"
-	extPropOmitEmpty = "x-omitempty"
-	extPropExtraTags = "x-go-extra-tags"
-	extMiddlewares   = "x-go-middlewares"
+	extPropGoType        = "x-go-type"
+	extPropOmitEmpty     = "x-omitempty"
+	extPropExtraTags     = "x-go-extra-tags"
+	extPropOptionalValue = "x-go-optional-value"
+	extPropString        = "x-go-string"
+	extMiddlewares       = "x-go-middlewares"
 )
 
 func extTypeName(extPropValue interface{}) (string, error) {
-	raw, ok := extPropValue.(json.RawMessage)
-	if !ok {
-		return "", fmt.Errorf("failed to convert type: %T", extPropValue)
-	}
 	var name string
-	if err := json.Unmarshal(raw, &name); err != nil {
-		return "", fmt.Errorf("failed to unmarshal json: %w", err)
-	}
-
-	return name, nil
+	err := extParseAny(extPropValue, &name)
+	return name, err
 }
 
 func extParseOmitEmpty(extPropValue interface{}) (bool, error) {
-	raw, ok := extPropValue.(json.RawMessage)
-	if !ok {
-		return false, fmt.Errorf("failed to convert type: %T", extPropValue)
-	}
-
-	var omitEmpty bool
-	if err := json.Unmarshal(raw, &omitEmpty); err != nil {
-		return false, fmt.Errorf("failed to unmarshal json: %w", err)
-	}
-
-	return omitEmpty, nil
+	return extParseBool(extPropValue)
 }
 
 func extExtraTags(extPropValue interface{}) (map[string]string, error) {
-	raw, ok := extPropValue.(json.RawMessage)
-	if !ok {
-		return nil, fmt.Errorf("failed to convert type: %T", extPropValue)
-	}
 	var tags map[string]string
-	if err := json.Unmarshal(raw, &tags); err != nil {
-		return nil, fmt.Errorf("failed to unmarshal json: %w", err)
-	}
-	return tags, nil
+	err := extParseAny(extPropValue, &tags)
+	return tags, err
 }
 
 func extParseMiddlewares(extPropValue interface{}) ([]string, error) {
+	var middlewares []string
+	err := extParseAny(extPropValue, &middlewares)
+	return middlewares, err
+}
+
+func extParseOptionalValue(extPropValue interface{}) (bool, error) {
+	return extParseBool(extPropValue)
+}
+
+func extParseBool(extPropValue interface{}) (bool, error) {
+	var b bool
+	err := extParseAny(extPropValue, &b)
+	return b, err
+}
+
+func extParseAny(extPropValue, target interface{}) error {
 	raw, ok := extPropValue.(json.RawMessage)
 	if !ok {
-		return nil, fmt.Errorf("failed to convert type: %T", extPropValue)
+		return fmt.Errorf("failed to convert type: %T", extPropValue)
 	}
-	var middlewares []string
-	if err := json.Unmarshal(raw, &middlewares); err != nil {
-		return nil, fmt.Errorf("failed to unmarshal json: %w", err)
+
+	if err := json.Unmarshal(raw, target); err != nil {
+		return fmt.Errorf("failed to unmarshal json: %w", err)
 	}
-	return middlewares, nil
+
+	return nil
 }

--- a/pkg/codegen/extension.go
+++ b/pkg/codegen/extension.go
@@ -20,10 +20,6 @@ func extTypeName(extPropValue interface{}) (string, error) {
 	return name, err
 }
 
-func extParseOmitEmpty(extPropValue interface{}) (bool, error) {
-	return extParseBool(extPropValue)
-}
-
 func extExtraTags(extPropValue interface{}) (map[string]string, error) {
 	var tags map[string]string
 	err := extParseAny(extPropValue, &tags)
@@ -34,10 +30,6 @@ func extParseMiddlewares(extPropValue interface{}) ([]string, error) {
 	var middlewares []string
 	err := extParseAny(extPropValue, &middlewares)
 	return middlewares, err
-}
-
-func extParseOptionalValue(extPropValue interface{}) (bool, error) {
-	return extParseBool(extPropValue)
 }
 
 func extParseBool(extPropValue interface{}) (bool, error) {

--- a/pkg/codegen/schema.go
+++ b/pkg/codegen/schema.go
@@ -473,7 +473,7 @@ func GenFieldsFromProperties(props []Property) []string {
 		// Support x-omitempty
 		omitEmpty := true
 		if _, ok := p.ExtensionProps.Extensions[extPropOmitEmpty]; ok {
-			if extOmitEmpty, err := extParseOmitEmpty(p.ExtensionProps.Extensions[extPropOmitEmpty]); err == nil {
+			if extOmitEmpty, err := extParseBool(p.ExtensionProps.Extensions[extPropOmitEmpty]); err == nil {
 				omitEmpty = extOmitEmpty
 			}
 		}


### PR DESCRIPTION
This commit implements x-go-optional-value, which forces the code
generator to generate value types (not pointer types) for optional
parameters. This closes issue #76.

Particularly, with how this commit is implemented, this is completely
allowed:

```yaml
    OptionalObject:
      description: Tests x-go-optional-value on the whole object
      x-go-optional-value: true
      properties:
        str1:
          type: string
        str2:
          type: string
        str_ptr1:
          type: string
          x-go-optional-value: false
        str_ptr2:
          type: string
          x-go-optional-value: false
```

The `x-go-optional-value`s can override each other depending on its
hierarchy.

This commit also implements x-go-string, which adds the ",string" suffix
into the JSON tag of a field, allowing that field to be parsed from a
string to an integer of any type. This closes issue #77.