### PR TITLE
fix(codegen): required param error implementation

### DIFF
--- a/internal/test/components/components.gen.go
+++ b/internal/test/components/components.gen.go
@@ -848,7 +848,7 @@ func (siw *ServerInterfaceWrapper) ParamsWithAddProps(w http.ResponseWriter, r *
 
 	if err := runtime.BindQueryParameter("simple", true, true, "p1", r.URL.Query(), &params.P1); err != nil {
 		err = fmt.Errorf("invalid format for parameter p1: %w", err)
-		siw.ErrorHandlerFunc(w, r, &InvalidParamFormatError{err, "p1"})
+		siw.ErrorHandlerFunc(w, r, &RequiredParamError{err, "p1"})
 		return
 	}
 
@@ -856,7 +856,7 @@ func (siw *ServerInterfaceWrapper) ParamsWithAddProps(w http.ResponseWriter, r *
 
 	if err := runtime.BindQueryParameter("form", true, true, "p2", r.URL.Query(), &params.P2); err != nil {
 		err = fmt.Errorf("invalid format for parameter p2: %w", err)
-		siw.ErrorHandlerFunc(w, r, &InvalidParamFormatError{err, "p2"})
+		siw.ErrorHandlerFunc(w, r, &RequiredParamError{err, "p2"})
 		return
 	}
 

--- a/internal/test/parameters/parameters.gen.go
+++ b/internal/test/parameters/parameters.gen.go
@@ -730,7 +730,7 @@ func (siw *ServerInterfaceWrapper) GetDeepObject(w http.ResponseWriter, r *http.
 
 	if err := runtime.BindQueryParameter("deepObject", true, true, "deepObj", r.URL.Query(), &params.DeepObj); err != nil {
 		err = fmt.Errorf("invalid format for parameter deepObj: %w", err)
-		siw.ErrorHandlerFunc(w, r, &InvalidParamFormatError{err, "deepObj"})
+		siw.ErrorHandlerFunc(w, r, &RequiredParamError{err, "deepObj"})
 		return
 	}
 

--- a/internal/test/schemas/schemas.gen.go
+++ b/internal/test/schemas/schemas.gen.go
@@ -397,7 +397,7 @@ func (siw *ServerInterfaceWrapper) Issue9(w http.ResponseWriter, r *http.Request
 
 	if err := runtime.BindQueryParameter("form", true, true, "foo", r.URL.Query(), &params.Foo); err != nil {
 		err = fmt.Errorf("invalid format for parameter foo: %w", err)
-		siw.ErrorHandlerFunc(w, r, &InvalidParamFormatError{err, "foo"})
+		siw.ErrorHandlerFunc(w, r, &RequiredParamError{err, "foo"})
 		return
 	}
 

--- a/internal/test/server/doc.go
+++ b/internal/test/server/doc.go
@@ -1,4 +1,4 @@
 package server
 
 //go:generate go run github.com/discord-gophers/goapi-gen --generate=types,server --package=server -o server.gen.go ../test-schema.yaml
-//go:generate go run github.com/matryer/moq -out server_moq.gen.go . ServerInterface
+//go:generate go run github.com/matryer/moq@latest -out server_moq.gen.go . ServerInterface

--- a/internal/test/server/server.gen.go
+++ b/internal/test/server/server.gen.go
@@ -408,7 +408,7 @@ func (siw *ServerInterfaceWrapper) GetWithArgs(w http.ResponseWriter, r *http.Re
 
 	if err := runtime.BindQueryParameter("form", true, true, "required_argument", r.URL.Query(), &params.RequiredArgument); err != nil {
 		err = fmt.Errorf("invalid format for parameter required_argument: %w", err)
-		siw.ErrorHandlerFunc(w, r, &InvalidParamFormatError{err, "required_argument"})
+		siw.ErrorHandlerFunc(w, r, &RequiredParamError{err, "required_argument"})
 		return
 	}
 

--- a/internal/test/server/server_test.go
+++ b/internal/test/server/server_test.go
@@ -40,7 +40,6 @@ func TestErrorHandlerFunc(t *testing.T) {
 		WithMiddlewares(noopMiddlewares),
 		WithErrorHandler(func(w http.ResponseWriter, r *http.Request, err error) {
 			w.Header().Set("Content-Type", "application/json")
-			// FIXME This should likely return a RequiredParamError, however due to binding it never does...
 			var requiredParamError *RequiredParamError
 			assert.True(t, errors.As(err, &requiredParamError))
 		}))

--- a/internal/test/server/server_test.go
+++ b/internal/test/server/server_test.go
@@ -1,6 +1,7 @@
 package server
 
 import (
+	"errors"
 	"net/http"
 	"net/http/httptest"
 	"testing"
@@ -40,8 +41,8 @@ func TestErrorHandlerFunc(t *testing.T) {
 		WithErrorHandler(func(w http.ResponseWriter, r *http.Request, err error) {
 			w.Header().Set("Content-Type", "application/json")
 			// FIXME This should likely return a RequiredParamError, however due to binding it never does...
-			// var requiredParamError *RequiredParamError
-			// assert.True(t, errors.As(err, &requiredParamError))
+			var requiredParamError *RequiredParamError
+			assert.True(t, errors.As(err, &requiredParamError))
 		}))
 
 	s := httptest.NewServer(h)

--- a/pkg/codegen/operations.go
+++ b/pkg/codegen/operations.go
@@ -349,22 +349,6 @@ func (r RequestBodyDefinition) TypeDef(opID string) *TypeDefinition {
 	}
 }
 
-// CustomType returns if body is a custom inline type, or pre-defined.
-// TODO: clean up the templates code, it can be simpler.
-func (r RequestBodyDefinition) CustomType() bool {
-	return r.Schema.RefType == ""
-}
-
-// Suffix returns "With{r.nameTag}Body"
-// Operation DoFoo would be suffixed with DoFooWithXMLBody.
-func (r RequestBodyDefinition) Suffix() string {
-	// The default response is never suffixed.
-	if r.Default {
-		return ""
-	}
-	return "With" + r.NameTag + "Body"
-}
-
 // FilterParameterDefinitionByType returns params which match the the type with
 // in.
 func FilterParameterDefinitionByType(params []ParameterDefinition, in string) []ParameterDefinition {

--- a/pkg/codegen/template_helpers.go
+++ b/pkg/codegen/template_helpers.go
@@ -19,6 +19,7 @@ import (
 	"sort"
 	"strings"
 	"text/template"
+	"unicode"
 
 	"github.com/kenshaw/snaker"
 )
@@ -100,6 +101,17 @@ func responseNameToStatusCode(responseName string) string {
 	}
 }
 
+// TitleWord converts a single worded string to title case.
+// This is a replacement to `strings.Title` which we used previously.
+// We didn't need strings.Title word boundary rules, and just want to Title the words directly,
+// to export them in most cases.
+// Thus, this function is simpler and more efficient.
+func TitleWord(s string) string {
+	r := []rune(s)
+	r[0] = unicode.ToUpper(r[0])
+	return string(r)
+}
+
 // TemplateFunctions generates the list of utlity and helpfer functions used by
 // the templates.
 var TemplateFunctions = template.FuncMap{
@@ -115,5 +127,5 @@ var TemplateFunctions = template.FuncMap{
 
 	"ucFirst": snaker.ForceCamelIdentifier,
 	"lower":   strings.ToLower,
-	"title":   strings.Title,
+	"title":   TitleWord,
 }

--- a/pkg/codegen/templates/middleware.tmpl
+++ b/pkg/codegen/templates/middleware.tmpl
@@ -46,7 +46,11 @@ func (siw *ServerInterfaceWrapper) {{$opid}}(w http.ResponseWriter, r *http.Requ
 			{{if .IsStyled}}
 			if err := runtime.BindQueryParameter("{{.Style}}", {{.Explode}}, {{.Required}}, "{{.ParamName}}", r.URL.Query(), &params.{{.GoName}}); err != nil {
 				err = fmt.Errorf("invalid format for parameter {{.ParamName}}: %w", err)
+				{{if .Required -}}
+				siw.ErrorHandlerFunc(w, r, &RequiredParamError{err, "{{.ParamName}}"})
+				{{else -}}
 				siw.ErrorHandlerFunc(w, r, &InvalidParamFormatError{err, "{{.ParamName}}"})
+				{{ end -}}
 				return
 			}
 			{{else}}


### PR DESCRIPTION
- return correctly required param
- delete dead code
- replace usage of deprecated function
- update go:generate command of moq to use latest, since it seems to be
  causing issues.
- update required param error tests

POSSIBLE BREAKING: multiple word call to `title` helper function (no
change in generation, and it generates valid code, but to be aware if
needs be).