### PR TITLE
refactor: middleware

### DIFF
--- a/examples/petstore-expanded/petstore.go
+++ b/examples/petstore-expanded/petstore.go
@@ -39,7 +39,7 @@ func main() {
 
 	// Use our validation middleware to check all requests against the
 	// OpenAPI schema.
-	r.Use(middleware.OapiRequestValidator(swagger))
+	r.Use(middleware.OAPIValidator(swagger))
 
 	// We now register our petStore above as the handler for the interface
 	api.Handler(petStore, api.WithRouter(r))

--- a/examples/petstore-expanded/petstore_test.go
+++ b/examples/petstore-expanded/petstore_test.go
@@ -37,7 +37,7 @@ func TestPetStore(t *testing.T) {
 
 	// Use our validation middleware to check all requests against the
 	// OpenAPI schema.
-	r.Use(middleware.OapiRequestValidator(swagger))
+	r.Use(middleware.OAPIValidator(swagger))
 
 	store := api.NewPetStore()
 	api.Handler(store, api.WithRouter(r))

--- a/middleware/oapi_validate.go
+++ b/middleware/oapi_validate.go
@@ -1,12 +1,12 @@
 // Package middleware implements middleware function for go-chi or net/http,
 // which validates incoming HTTP requests to make sure that they conform to the given OAPI 3.0 specification.
-// When OAPI validation failes on the request, we return an HTTP/400.
+// When OAPI validation failes on the request, we return an HTTP/400.[refactor/middleware 7ad632e] diff: revert package doc comment deletion
 package middleware
 
 import (
-	"context"
 	"encoding/json"
 	"encoding/xml"
+	"errors"
 	"fmt"
 	"net/http"
 	"strings"
@@ -19,8 +19,12 @@ import (
 
 // Options to customize request validation, openapi3filter specified options will be passed through.
 type Options struct {
-	Options openapi3filter.Options
+	Options *openapi3filter.Options
 	ErrRespContentType
+
+	respContentTypeHeader string
+
+	router routers.Router
 }
 
 // ErrRespContentType represents the support content-types for the response when a validation error occurs
@@ -33,40 +37,54 @@ const (
 	ErrRespContentTypeXML   ErrRespContentType = "application/xml"
 )
 
-// OapiRequestValidator Creates middleware to validate request by swagger spec.
-// This middleware is good for net/http either since go-chi is 100% compatible with net/http.
-func OapiRequestValidator(swagger *openapi3.T) func(next http.Handler) http.Handler {
-	return OapiRequestValidatorWithOptions(swagger, nil)
+// WithErrContentType sets the content type of the error response
+func WithErrContentType(contentType ErrRespContentType) func(*Options) {
+	return func(options *Options) {
+		options.ErrRespContentType = contentType
+		options.respContentTypeHeader = string(contentType) + "; charset=utf-8"
+	}
 }
 
-// OapiRequestValidatorWithOptions Creates middleware to validate request by swagger spec.
-// This middleware is good for net/http either since go-chi is 100% compatible with net/http.
-func OapiRequestValidatorWithOptions(swagger *openapi3.T, options *Options) func(next http.Handler) http.Handler {
-	router, err := gorillamux.NewRouter(swagger)
+// WithOptions sets the openapi3filter options for the middleware
+func WithOptions(opt *openapi3filter.Options) func(*Options) {
+	return func(options *Options) {
+		options.Options = opt
+	}
+}
+
+func OAPIValidator(swagger *openapi3.T, opts ...func(*Options)) func(next http.Handler) http.Handler {
+	r, err := gorillamux.NewRouter(swagger)
 	if err != nil {
-		panic(err)
+		// user error
+		panic("could not create router: " + err.Error())
+	}
+
+	options := Options{
+		ErrRespContentType:    ErrRespContentTypePlain,
+		respContentTypeHeader: string(ErrRespContentTypePlain) + "; charset=utf-8",
+		router:                r,
+	}
+
+	for _, opt := range opts {
+		opt(&options)
 	}
 
 	return func(next http.Handler) http.Handler {
 		return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-
 			// validate request
-			if statusCode, err := validateRequest(r, router, options); err != nil {
-				contentType := ErrRespContentTypePlain
-				if options != nil && options.ErrRespContentType != "" {
-					contentType = options.ErrRespContentType
-				}
-				w.Header().Set("Content-Type", string(contentType)+"; charset=utf-8")
+			if statusCode, err := validateOAPIRequest(r, options); err != nil {
+				w.Header().Set("Content-Type", options.respContentTypeHeader)
 				w.Header().Set("X-Content-Type-Options", "nosniff")
 				w.WriteHeader(statusCode)
 
 				body := []byte(err.Error())
-				switch contentType {
+				switch options.ErrRespContentType {
 				case ErrRespContentTypeJSON:
 					body, _ = json.Marshal(err.Error())
 				case ErrRespContentTypeXML:
 					body, _ = xml.Marshal(err.Error())
 				}
+
 				fmt.Fprintln(w, string(body))
 				return
 			}
@@ -75,67 +93,60 @@ func OapiRequestValidatorWithOptions(swagger *openapi3.T, options *Options) func
 			next.ServeHTTP(w, r)
 		})
 	}
-
 }
 
 // This function is called from the middleware above and actually does the work
 // of validating a request.
-func validateRequest(r *http.Request, router routers.Router, options *Options) (int, error) {
-
-	// Find route
-	route, pathParams, err := router.FindRoute(r)
+func validateOAPIRequest(r *http.Request, options Options) (int, error) {
+	// pain
+	route, pathParams, err := options.router.FindRoute(r)
 	if err != nil {
-		return http.StatusBadRequest, err // We failed to find a matching route for the request.
+		return http.StatusBadRequest, err
 	}
 
 	// Validate request
-	requestValidationInput := &openapi3filter.RequestValidationInput{
+	reqValidation := &openapi3filter.RequestValidationInput{
 		Request:    r,
 		PathParams: pathParams,
 		Route:      route,
-	}
-
-	if options != nil {
-		requestValidationInput.Options = &options.Options
+		Options:    options.Options,
 	}
 
 	// Validate security before any other validation, unless options.Options.MultiError is true
-	if options == nil || !options.Options.MultiError {
-		if err := validateSecurity(requestValidationInput); err != nil {
+	if options.Options == nil || !options.Options.MultiError {
+		security := reqValidation.Route.Operation.Security
+		if security == nil {
+			security = &reqValidation.Route.Spec.Security
+		}
+
+		if err := openapi3filter.ValidateSecurityRequirements(r.Context(), reqValidation, *security); err != nil {
 			return http.StatusUnauthorized, err
 		}
 	}
 
 	// Validate the rest of the request
-	if err := openapi3filter.ValidateRequest(context.Background(), requestValidationInput); err != nil {
-		switch e := err.(type) {
-		case *openapi3filter.RequestError:
+	if err := openapi3filter.ValidateRequest(r.Context(), reqValidation); err != nil {
+		reqError := &openapi3filter.RequestError{}
+		secError := &openapi3filter.SecurityRequirementsError{}
+		otherErrr := &openapi3.MultiError{}
+
+		switch {
+		case errors.As(err, &reqError):
 			// We've got a bad request
 			// Split up the verbose error by lines and return the first one
 			// openapi errors seem to be multi-line with a decent message on the first
-			errorLines := strings.Split(e.Error(), "\n")
+			errorLines := strings.Split(err.Error(), "\n")
 			return http.StatusBadRequest, fmt.Errorf(errorLines[0])
-		case *openapi3filter.SecurityRequirementsError:
+		case errors.As(err, &secError):
 			return http.StatusUnauthorized, err
-		default:
+		case errors.As(err, &otherErrr):
 			// This case occurs when options.Options.MultiError is true.
-			// TODO(zlb): Find a better way to handle this.
+			return http.StatusBadRequest, err
+		default:
+			// Shouldn't happen too much
 			return http.StatusInternalServerError, fmt.Errorf("error validating route: %s", err.Error())
 		}
 	}
 
 	return http.StatusOK, nil
-}
-
-func validateSecurity(input *openapi3filter.RequestValidationInput) error {
-
-	security := input.Route.Operation.Security
-	if security == nil {
-		security = &input.Route.Spec.Security
-		if security == nil {
-			return nil
-		}
-	}
-
-	return openapi3filter.ValidateSecurityRequirements(context.Background(), input, *security)
 }

--- a/middleware/oapi_validate.go
+++ b/middleware/oapi_validate.go
@@ -1,6 +1,6 @@
 // Package middleware implements middleware function for go-chi or net/http,
 // which validates incoming HTTP requests to make sure that they conform to the given OAPI 3.0 specification.
-// When OAPI validation failes on the request, we return an HTTP/400.[refactor/middleware 7ad632e] diff: revert package doc comment deletion
+// When OAPI validation failes on the request, we return an HTTP/400.
 package middleware
 
 import (


### PR DESCRIPTION
This PR refactors the middleware package in such a way that promotes non-breaking changes later on, thus, we could now easily support #79 (presented we actually want that and get to it)

It is also slightly safer, since users can't change the options at runtime, which could have been a tiny issue if it ever happened

Change for REST API consumer: close to none (now doesn't return 500 in
case of multiple errors)
Change for dev: Slight function signature change

BREAKING: Middleware function signature have changed (as well as their
names)
FIX: fixes unknown errors due to multierror