### PR TITLE
make handler return type interfaces

### DIFF
--- a/examples/petstore-expanded/api/petstore.gen.go
+++ b/examples/petstore-expanded/api/petstore.gen.go
@@ -65,11 +65,6 @@ func (AddPetJSONRequestBody) Bind(*http.Request) error {
 	return nil
 }
 
-// Responser is an interface for responding to a request.
-type Responser interface {
-	Response() *Response
-}
-
 // Response is a common response struct for all the API calls.
 // A Response object may be instantiated via functions for specific operation responses.
 // It may also be instantiated directly, for the purpose of responding with a single status code.
@@ -79,29 +74,12 @@ type Response struct {
 	ContentType string
 }
 
-// Response implements the Responser interface.
-func (r *Response) Response() *Response {
-	return r
-}
-
 // Render implements the render.Renderer interface. It sets the Content-Type header
 // and status code based on the response definition.
 func (resp *Response) Render(w http.ResponseWriter, r *http.Request) error {
 	w.Header().Set("Content-Type", resp.ContentType)
 	render.Status(r, resp.Code)
 	return nil
-}
-
-// Status is a builder method to override the default status code for a response.
-func (resp *Response) Status(code int) *Response {
-	resp.Code = code
-	return resp
-}
-
-// ContentType is a builder method to override the default content type for a response.
-func (resp *Response) ContentTyp(contentType string) *Response {
-	resp.ContentType = contentType
-	return resp
 }
 
 // MarshalJSON implements the json.Marshaler interface.
@@ -190,16 +168,16 @@ func FindPetByIDJSONDefaultResponse(body Error) *Response {
 type ServerInterface interface {
 	// Returns all pets
 	// (GET /pets)
-	FindPets(w http.ResponseWriter, r *http.Request, params FindPetsParams) Responser
+	FindPets(w http.ResponseWriter, r *http.Request, params FindPetsParams) render.Renderer
 	// Creates a new pet
 	// (POST /pets)
-	AddPet(w http.ResponseWriter, r *http.Request) Responser
+	AddPet(w http.ResponseWriter, r *http.Request) render.Renderer
 	// Deletes a pet by ID
 	// (DELETE /pets/{id})
-	DeletePet(w http.ResponseWriter, r *http.Request, id int64) Responser
+	DeletePet(w http.ResponseWriter, r *http.Request, id int64) render.Renderer
 	// Returns a pet by ID
 	// (GET /pets/{id})
-	FindPetByID(w http.ResponseWriter, r *http.Request, id int64) Responser
+	FindPetByID(w http.ResponseWriter, r *http.Request, id int64) render.Renderer
 }
 
 // ServerInterfaceWrapper converts contexts to parameters.
@@ -235,12 +213,7 @@ func (siw *ServerInterfaceWrapper) FindPets(w http.ResponseWriter, r *http.Reque
 	var handler = http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		resp := siw.Handler.FindPets(w, r, params)
 		if resp != nil {
-			rsp := resp.Response()
-			if rsp.Body != nil {
-				render.Render(w, r, rsp)
-			} else {
-				w.WriteHeader(rsp.Code)
-			}
+			render.Render(w, r, resp)
 		}
 	})
 
@@ -254,12 +227,7 @@ func (siw *ServerInterfaceWrapper) AddPet(w http.ResponseWriter, r *http.Request
 	var handler = http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		resp := siw.Handler.AddPet(w, r)
 		if resp != nil {
-			rsp := resp.Response()
-			if rsp.Body != nil {
-				render.Render(w, r, rsp)
-			} else {
-				w.WriteHeader(rsp.Code)
-			}
+			render.Render(w, r, resp)
 		}
 	})
 
@@ -281,12 +249,7 @@ func (siw *ServerInterfaceWrapper) DeletePet(w http.ResponseWriter, r *http.Requ
 	var handler = http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		resp := siw.Handler.DeletePet(w, r, id)
 		if resp != nil {
-			rsp := resp.Response()
-			if rsp.Body != nil {
-				render.Render(w, r, rsp)
-			} else {
-				w.WriteHeader(rsp.Code)
-			}
+			render.Render(w, r, resp)
 		}
 	})
 
@@ -308,12 +271,7 @@ func (siw *ServerInterfaceWrapper) FindPetByID(w http.ResponseWriter, r *http.Re
 	var handler = http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		resp := siw.Handler.FindPetByID(w, r, id)
 		if resp != nil {
-			rsp := resp.Response()
-			if rsp.Body != nil {
-				render.Render(w, r, rsp)
-			} else {
-				w.WriteHeader(rsp.Code)
-			}
+			render.Render(w, r, resp)
 		}
 	})
 

--- a/examples/petstore-expanded/api/petstore.gen.go
+++ b/examples/petstore-expanded/api/petstore.gen.go
@@ -76,7 +76,7 @@ type Response struct {
 
 // Render implements the render.Renderer interface. It sets the Content-Type header
 // and status code based on the response definition.
-func (resp *Response) Render(w http.ResponseWriter, r *http.Request) error {
+func (resp Response) Render(w http.ResponseWriter, r *http.Request) error {
 	w.Header().Set("Content-Type", resp.ContentType)
 	render.Status(r, resp.Code)
 	return nil
@@ -84,20 +84,20 @@ func (resp *Response) Render(w http.ResponseWriter, r *http.Request) error {
 
 // MarshalJSON implements the json.Marshaler interface.
 // This is used to only marshal the body of the response.
-func (resp *Response) MarshalJSON() ([]byte, error) {
+func (resp Response) MarshalJSON() ([]byte, error) {
 	return json.Marshal(resp.Body)
 }
 
 // MarshalXML implements the xml.Marshaler interface.
 // This is used to only marshal the body of the response.
-func (resp *Response) MarshalXML(e *xml.Encoder, start xml.StartElement) error {
+func (resp Response) MarshalXML(e *xml.Encoder, start xml.StartElement) error {
 	return e.Encode(resp.Body)
 }
 
 // FindPetsJSON200Response is a constructor method for a FindPets response.
-// A *Response is returned with the configured status code and content type from the spec.
-func FindPetsJSON200Response(body []Pet) *Response {
-	return &Response{
+// A Response is returned with the configured status code and content type from the spec.
+func FindPetsJSON200Response(body []Pet) Response {
+	return Response{
 		Body:        body,
 		Code:        200,
 		ContentType: "application/json",
@@ -105,9 +105,9 @@ func FindPetsJSON200Response(body []Pet) *Response {
 }
 
 // FindPetsJSONDefaultResponse is a constructor method for a FindPets response.
-// A *Response is returned with the configured status code and content type from the spec.
-func FindPetsJSONDefaultResponse(body Error) *Response {
-	return &Response{
+// A Response is returned with the configured status code and content type from the spec.
+func FindPetsJSONDefaultResponse(body Error) Response {
+	return Response{
 		Body:        body,
 		Code:        200,
 		ContentType: "application/json",
@@ -115,9 +115,9 @@ func FindPetsJSONDefaultResponse(body Error) *Response {
 }
 
 // AddPetJSON201Response is a constructor method for a AddPet response.
-// A *Response is returned with the configured status code and content type from the spec.
-func AddPetJSON201Response(body Pet) *Response {
-	return &Response{
+// A Response is returned with the configured status code and content type from the spec.
+func AddPetJSON201Response(body Pet) Response {
+	return Response{
 		Body:        body,
 		Code:        201,
 		ContentType: "application/json",
@@ -125,9 +125,9 @@ func AddPetJSON201Response(body Pet) *Response {
 }
 
 // AddPetJSONDefaultResponse is a constructor method for a AddPet response.
-// A *Response is returned with the configured status code and content type from the spec.
-func AddPetJSONDefaultResponse(body Error) *Response {
-	return &Response{
+// A Response is returned with the configured status code and content type from the spec.
+func AddPetJSONDefaultResponse(body Error) Response {
+	return Response{
 		Body:        body,
 		Code:        200,
 		ContentType: "application/json",
@@ -135,9 +135,9 @@ func AddPetJSONDefaultResponse(body Error) *Response {
 }
 
 // DeletePetJSONDefaultResponse is a constructor method for a DeletePet response.
-// A *Response is returned with the configured status code and content type from the spec.
-func DeletePetJSONDefaultResponse(body Error) *Response {
-	return &Response{
+// A Response is returned with the configured status code and content type from the spec.
+func DeletePetJSONDefaultResponse(body Error) Response {
+	return Response{
 		Body:        body,
 		Code:        200,
 		ContentType: "application/json",
@@ -145,9 +145,9 @@ func DeletePetJSONDefaultResponse(body Error) *Response {
 }
 
 // FindPetByIDJSON200Response is a constructor method for a FindPetByID response.
-// A *Response is returned with the configured status code and content type from the spec.
-func FindPetByIDJSON200Response(body Pet) *Response {
-	return &Response{
+// A Response is returned with the configured status code and content type from the spec.
+func FindPetByIDJSON200Response(body Pet) Response {
+	return Response{
 		Body:        body,
 		Code:        200,
 		ContentType: "application/json",
@@ -155,9 +155,9 @@ func FindPetByIDJSON200Response(body Pet) *Response {
 }
 
 // FindPetByIDJSONDefaultResponse is a constructor method for a FindPetByID response.
-// A *Response is returned with the configured status code and content type from the spec.
-func FindPetByIDJSONDefaultResponse(body Error) *Response {
-	return &Response{
+// A Response is returned with the configured status code and content type from the spec.
+func FindPetByIDJSONDefaultResponse(body Error) Response {
+	return Response{
 		Body:        body,
 		Code:        200,
 		ContentType: "application/json",
@@ -213,6 +213,11 @@ func (siw *ServerInterfaceWrapper) FindPets(w http.ResponseWriter, r *http.Reque
 	var handler = http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		resp := siw.Handler.FindPets(w, r, params)
 		if resp != nil {
+			if resp, ok := resp.(Response); ok && resp.Body == nil {
+				w.WriteHeader(resp.Code)
+				return
+			}
+
 			render.Render(w, r, resp)
 		}
 	})
@@ -227,6 +232,11 @@ func (siw *ServerInterfaceWrapper) AddPet(w http.ResponseWriter, r *http.Request
 	var handler = http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		resp := siw.Handler.AddPet(w, r)
 		if resp != nil {
+			if resp, ok := resp.(Response); ok && resp.Body == nil {
+				w.WriteHeader(resp.Code)
+				return
+			}
+
 			render.Render(w, r, resp)
 		}
 	})
@@ -249,6 +259,11 @@ func (siw *ServerInterfaceWrapper) DeletePet(w http.ResponseWriter, r *http.Requ
 	var handler = http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		resp := siw.Handler.DeletePet(w, r, id)
 		if resp != nil {
+			if resp, ok := resp.(Response); ok && resp.Body == nil {
+				w.WriteHeader(resp.Code)
+				return
+			}
+
 			render.Render(w, r, resp)
 		}
 	})
@@ -271,6 +286,11 @@ func (siw *ServerInterfaceWrapper) FindPetByID(w http.ResponseWriter, r *http.Re
 	var handler = http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		resp := siw.Handler.FindPetByID(w, r, id)
 		if resp != nil {
+			if resp, ok := resp.(Response); ok && resp.Body == nil {
+				w.WriteHeader(resp.Code)
+				return
+			}
+
 			render.Render(w, r, resp)
 		}
 	})

--- a/internal/test/components/components.gen.go
+++ b/internal/test/components/components.gen.go
@@ -163,7 +163,7 @@ type Response struct {
 
 // Render implements the render.Renderer interface. It sets the Content-Type header
 // and status code based on the response definition.
-func (resp *Response) Render(w http.ResponseWriter, r *http.Request) error {
+func (resp Response) Render(w http.ResponseWriter, r *http.Request) error {
 	w.Header().Set("Content-Type", resp.ContentType)
 	render.Status(r, resp.Code)
 	return nil
@@ -171,18 +171,18 @@ func (resp *Response) Render(w http.ResponseWriter, r *http.Request) error {
 
 // MarshalJSON implements the json.Marshaler interface.
 // This is used to only marshal the body of the response.
-func (resp *Response) MarshalJSON() ([]byte, error) {
+func (resp Response) MarshalJSON() ([]byte, error) {
 	return json.Marshal(resp.Body)
 }
 
 // MarshalXML implements the xml.Marshaler interface.
 // This is used to only marshal the body of the response.
-func (resp *Response) MarshalXML(e *xml.Encoder, start xml.StartElement) error {
+func (resp Response) MarshalXML(e *xml.Encoder, start xml.StartElement) error {
 	return e.Encode(resp.Body)
 }
 
 // EnsureEverythingIsReferencedJSON200Response is a constructor method for a EnsureEverythingIsReferenced response.
-// A *Response is returned with the configured status code and content type from the spec.
+// A Response is returned with the configured status code and content type from the spec.
 func EnsureEverythingIsReferencedJSON200Response(body struct {
 	// Has additional properties with schema for dictionaries
 	Five *AdditionalPropertiesObject5 `json:"five,omitempty"`
@@ -208,8 +208,8 @@ func EnsureEverythingIsReferencedJSON200Response(body struct {
 
 	// Does not allow additional properties
 	Two *AdditionalPropertiesObject2 `json:"two,omitempty"`
-}) *Response {
-	return &Response{
+}) Response {
+	return Response{
 		Body:        body,
 		Code:        200,
 		ContentType: "application/json",
@@ -217,11 +217,11 @@ func EnsureEverythingIsReferencedJSON200Response(body struct {
 }
 
 // EnsureEverythingIsReferencedJSONDefaultResponse is a constructor method for a EnsureEverythingIsReferenced response.
-// A *Response is returned with the configured status code and content type from the spec.
+// A Response is returned with the configured status code and content type from the spec.
 func EnsureEverythingIsReferencedJSONDefaultResponse(body struct {
 	Field SchemaObject `json:"Field"`
-}) *Response {
-	return &Response{
+}) Response {
+	return Response{
 		Body:        body,
 		Code:        200,
 		ContentType: "application/json",
@@ -851,6 +851,11 @@ func (siw *ServerInterfaceWrapper) EnsureEverythingIsReferenced(w http.ResponseW
 	var handler = http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		resp := siw.Handler.EnsureEverythingIsReferenced(w, r)
 		if resp != nil {
+			if resp, ok := resp.(Response); ok && resp.Body == nil {
+				w.WriteHeader(resp.Code)
+				return
+			}
+
 			render.Render(w, r, resp)
 		}
 	})
@@ -884,6 +889,11 @@ func (siw *ServerInterfaceWrapper) ParamsWithAddProps(w http.ResponseWriter, r *
 	var handler = http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		resp := siw.Handler.ParamsWithAddProps(w, r, params)
 		if resp != nil {
+			if resp, ok := resp.(Response); ok && resp.Body == nil {
+				w.WriteHeader(resp.Code)
+				return
+			}
+
 			render.Render(w, r, resp)
 		}
 	})
@@ -898,6 +908,11 @@ func (siw *ServerInterfaceWrapper) BodyWithAddProps(w http.ResponseWriter, r *ht
 	var handler = http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		resp := siw.Handler.BodyWithAddProps(w, r)
 		if resp != nil {
+			if resp, ok := resp.(Response); ok && resp.Body == nil {
+				w.WriteHeader(resp.Code)
+				return
+			}
+
 			render.Render(w, r, resp)
 		}
 	})

--- a/internal/test/components/components.gen.go
+++ b/internal/test/components/components.gen.go
@@ -152,19 +152,29 @@ func (BodyWithAddPropsJSONRequestBody) Bind(*http.Request) error {
 	return nil
 }
 
+// Responser is an interface for responding to a request.
+type Responser interface {
+	Response() *Response
+}
+
 // Response is a common response struct for all the API calls.
 // A Response object may be instantiated via functions for specific operation responses.
 // It may also be instantiated directly, for the purpose of responding with a single status code.
 type Response struct {
-	body        interface{}
+	Body        interface{}
 	Code        int
-	contentType string
+	ContentType string
+}
+
+// Response implements the Responser interface.
+func (r *Response) Response() *Response {
+	return r
 }
 
 // Render implements the render.Renderer interface. It sets the Content-Type header
 // and status code based on the response definition.
 func (resp *Response) Render(w http.ResponseWriter, r *http.Request) error {
-	w.Header().Set("Content-Type", resp.contentType)
+	w.Header().Set("Content-Type", resp.ContentType)
 	render.Status(r, resp.Code)
 	return nil
 }
@@ -176,21 +186,21 @@ func (resp *Response) Status(code int) *Response {
 }
 
 // ContentType is a builder method to override the default content type for a response.
-func (resp *Response) ContentType(contentType string) *Response {
-	resp.contentType = contentType
+func (resp *Response) ContentTyp(contentType string) *Response {
+	resp.ContentType = contentType
 	return resp
 }
 
 // MarshalJSON implements the json.Marshaler interface.
 // This is used to only marshal the body of the response.
 func (resp *Response) MarshalJSON() ([]byte, error) {
-	return json.Marshal(resp.body)
+	return json.Marshal(resp.Body)
 }
 
 // MarshalXML implements the xml.Marshaler interface.
 // This is used to only marshal the body of the response.
 func (resp *Response) MarshalXML(e *xml.Encoder, start xml.StartElement) error {
-	return e.Encode(resp.body)
+	return e.Encode(resp.Body)
 }
 
 // EnsureEverythingIsReferencedJSON200Response is a constructor method for a EnsureEverythingIsReferenced response.
@@ -222,9 +232,9 @@ func EnsureEverythingIsReferencedJSON200Response(body struct {
 	Two *AdditionalPropertiesObject2 `json:"two,omitempty"`
 }) *Response {
 	return &Response{
-		body:        body,
+		Body:        body,
 		Code:        200,
-		contentType: "application/json",
+		ContentType: "application/json",
 	}
 }
 
@@ -234,9 +244,9 @@ func EnsureEverythingIsReferencedJSONDefaultResponse(body struct {
 	Field SchemaObject `json:"Field"`
 }) *Response {
 	return &Response{
-		body:        body,
+		Body:        body,
 		Code:        200,
-		contentType: "application/json",
+		ContentType: "application/json",
 	}
 }
 
@@ -840,13 +850,13 @@ func (a AdditionalPropertiesObject5) MarshalJSON() ([]byte, error) {
 type ServerInterface interface {
 
 	// (GET /ensure-everything-is-referenced)
-	EnsureEverythingIsReferenced(w http.ResponseWriter, r *http.Request) *Response
+	EnsureEverythingIsReferenced(w http.ResponseWriter, r *http.Request) Responser
 
 	// (GET /params_with_add_props)
-	ParamsWithAddProps(w http.ResponseWriter, r *http.Request, params ParamsWithAddPropsParams) *Response
+	ParamsWithAddProps(w http.ResponseWriter, r *http.Request, params ParamsWithAddPropsParams) Responser
 
 	// (POST /params_with_add_props)
-	BodyWithAddProps(w http.ResponseWriter, r *http.Request) *Response
+	BodyWithAddProps(w http.ResponseWriter, r *http.Request) Responser
 }
 
 // ServerInterfaceWrapper converts contexts to parameters.
@@ -863,10 +873,11 @@ func (siw *ServerInterfaceWrapper) EnsureEverythingIsReferenced(w http.ResponseW
 	var handler = http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		resp := siw.Handler.EnsureEverythingIsReferenced(w, r)
 		if resp != nil {
-			if resp.body != nil {
-				render.Render(w, r, resp)
+			rsp := resp.Response()
+			if rsp.Body != nil {
+				render.Render(w, r, rsp)
 			} else {
-				w.WriteHeader(resp.Code)
+				w.WriteHeader(rsp.Code)
 			}
 		}
 	})
@@ -900,10 +911,11 @@ func (siw *ServerInterfaceWrapper) ParamsWithAddProps(w http.ResponseWriter, r *
 	var handler = http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		resp := siw.Handler.ParamsWithAddProps(w, r, params)
 		if resp != nil {
-			if resp.body != nil {
-				render.Render(w, r, resp)
+			rsp := resp.Response()
+			if rsp.Body != nil {
+				render.Render(w, r, rsp)
 			} else {
-				w.WriteHeader(resp.Code)
+				w.WriteHeader(rsp.Code)
 			}
 		}
 	})
@@ -918,10 +930,11 @@ func (siw *ServerInterfaceWrapper) BodyWithAddProps(w http.ResponseWriter, r *ht
 	var handler = http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		resp := siw.Handler.BodyWithAddProps(w, r)
 		if resp != nil {
-			if resp.body != nil {
-				render.Render(w, r, resp)
+			rsp := resp.Response()
+			if rsp.Body != nil {
+				render.Render(w, r, rsp)
 			} else {
-				w.WriteHeader(resp.Code)
+				w.WriteHeader(rsp.Code)
 			}
 		}
 	})

--- a/internal/test/components/components.gen.go
+++ b/internal/test/components/components.gen.go
@@ -152,11 +152,6 @@ func (BodyWithAddPropsJSONRequestBody) Bind(*http.Request) error {
 	return nil
 }
 
-// Responser is an interface for responding to a request.
-type Responser interface {
-	Response() *Response
-}
-
 // Response is a common response struct for all the API calls.
 // A Response object may be instantiated via functions for specific operation responses.
 // It may also be instantiated directly, for the purpose of responding with a single status code.
@@ -166,29 +161,12 @@ type Response struct {
 	ContentType string
 }
 
-// Response implements the Responser interface.
-func (r *Response) Response() *Response {
-	return r
-}
-
 // Render implements the render.Renderer interface. It sets the Content-Type header
 // and status code based on the response definition.
 func (resp *Response) Render(w http.ResponseWriter, r *http.Request) error {
 	w.Header().Set("Content-Type", resp.ContentType)
 	render.Status(r, resp.Code)
 	return nil
-}
-
-// Status is a builder method to override the default status code for a response.
-func (resp *Response) Status(code int) *Response {
-	resp.Code = code
-	return resp
-}
-
-// ContentType is a builder method to override the default content type for a response.
-func (resp *Response) ContentTyp(contentType string) *Response {
-	resp.ContentType = contentType
-	return resp
 }
 
 // MarshalJSON implements the json.Marshaler interface.
@@ -850,13 +828,13 @@ func (a AdditionalPropertiesObject5) MarshalJSON() ([]byte, error) {
 type ServerInterface interface {
 
 	// (GET /ensure-everything-is-referenced)
-	EnsureEverythingIsReferenced(w http.ResponseWriter, r *http.Request) Responser
+	EnsureEverythingIsReferenced(w http.ResponseWriter, r *http.Request) render.Renderer
 
 	// (GET /params_with_add_props)
-	ParamsWithAddProps(w http.ResponseWriter, r *http.Request, params ParamsWithAddPropsParams) Responser
+	ParamsWithAddProps(w http.ResponseWriter, r *http.Request, params ParamsWithAddPropsParams) render.Renderer
 
 	// (POST /params_with_add_props)
-	BodyWithAddProps(w http.ResponseWriter, r *http.Request) Responser
+	BodyWithAddProps(w http.ResponseWriter, r *http.Request) render.Renderer
 }
 
 // ServerInterfaceWrapper converts contexts to parameters.
@@ -873,12 +851,7 @@ func (siw *ServerInterfaceWrapper) EnsureEverythingIsReferenced(w http.ResponseW
 	var handler = http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		resp := siw.Handler.EnsureEverythingIsReferenced(w, r)
 		if resp != nil {
-			rsp := resp.Response()
-			if rsp.Body != nil {
-				render.Render(w, r, rsp)
-			} else {
-				w.WriteHeader(rsp.Code)
-			}
+			render.Render(w, r, resp)
 		}
 	})
 
@@ -911,12 +884,7 @@ func (siw *ServerInterfaceWrapper) ParamsWithAddProps(w http.ResponseWriter, r *
 	var handler = http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		resp := siw.Handler.ParamsWithAddProps(w, r, params)
 		if resp != nil {
-			rsp := resp.Response()
-			if rsp.Body != nil {
-				render.Render(w, r, rsp)
-			} else {
-				w.WriteHeader(rsp.Code)
-			}
+			render.Render(w, r, resp)
 		}
 	})
 
@@ -930,12 +898,7 @@ func (siw *ServerInterfaceWrapper) BodyWithAddProps(w http.ResponseWriter, r *ht
 	var handler = http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		resp := siw.Handler.BodyWithAddProps(w, r)
 		if resp != nil {
-			rsp := resp.Response()
-			if rsp.Body != nil {
-				render.Render(w, r, rsp)
-			} else {
-				w.WriteHeader(rsp.Code)
-			}
+			render.Render(w, r, resp)
 		}
 	})
 

--- a/internal/test/parameters/parameters.gen.go
+++ b/internal/test/parameters/parameters.gen.go
@@ -135,7 +135,7 @@ type Response struct {
 
 // Render implements the render.Renderer interface. It sets the Content-Type header
 // and status code based on the response definition.
-func (resp *Response) Render(w http.ResponseWriter, r *http.Request) error {
+func (resp Response) Render(w http.ResponseWriter, r *http.Request) error {
 	w.Header().Set("Content-Type", resp.ContentType)
 	render.Status(r, resp.Code)
 	return nil
@@ -143,13 +143,13 @@ func (resp *Response) Render(w http.ResponseWriter, r *http.Request) error {
 
 // MarshalJSON implements the json.Marshaler interface.
 // This is used to only marshal the body of the response.
-func (resp *Response) MarshalJSON() ([]byte, error) {
+func (resp Response) MarshalJSON() ([]byte, error) {
 	return json.Marshal(resp.Body)
 }
 
 // MarshalXML implements the xml.Marshaler interface.
 // This is used to only marshal the body of the response.
-func (resp *Response) MarshalXML(e *xml.Encoder, start xml.StartElement) error {
+func (resp Response) MarshalXML(e *xml.Encoder, start xml.StartElement) error {
 	return e.Encode(resp.Body)
 }
 
@@ -239,6 +239,11 @@ func (siw *ServerInterfaceWrapper) GetContentObject(w http.ResponseWriter, r *ht
 	var handler = http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		resp := siw.Handler.GetContentObject(w, r, param)
 		if resp != nil {
+			if resp, ok := resp.(Response); ok && resp.Body == nil {
+				w.WriteHeader(resp.Code)
+				return
+			}
+
 			render.Render(w, r, resp)
 		}
 	})
@@ -345,6 +350,11 @@ func (siw *ServerInterfaceWrapper) GetCookie(w http.ResponseWriter, r *http.Requ
 	var handler = http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		resp := siw.Handler.GetCookie(w, r, params)
 		if resp != nil {
+			if resp, ok := resp.(Response); ok && resp.Body == nil {
+				w.WriteHeader(resp.Code)
+				return
+			}
+
 			render.Render(w, r, resp)
 		}
 	})
@@ -508,6 +518,11 @@ func (siw *ServerInterfaceWrapper) GetHeader(w http.ResponseWriter, r *http.Requ
 	var handler = http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		resp := siw.Handler.GetHeader(w, r, params)
 		if resp != nil {
+			if resp, ok := resp.(Response); ok && resp.Body == nil {
+				w.WriteHeader(resp.Code)
+				return
+			}
+
 			render.Render(w, r, resp)
 		}
 	})
@@ -530,6 +545,11 @@ func (siw *ServerInterfaceWrapper) GetLabelExplodeArray(w http.ResponseWriter, r
 	var handler = http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		resp := siw.Handler.GetLabelExplodeArray(w, r, param)
 		if resp != nil {
+			if resp, ok := resp.(Response); ok && resp.Body == nil {
+				w.WriteHeader(resp.Code)
+				return
+			}
+
 			render.Render(w, r, resp)
 		}
 	})
@@ -552,6 +572,11 @@ func (siw *ServerInterfaceWrapper) GetLabelExplodeObject(w http.ResponseWriter, 
 	var handler = http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		resp := siw.Handler.GetLabelExplodeObject(w, r, param)
 		if resp != nil {
+			if resp, ok := resp.(Response); ok && resp.Body == nil {
+				w.WriteHeader(resp.Code)
+				return
+			}
+
 			render.Render(w, r, resp)
 		}
 	})
@@ -574,6 +599,11 @@ func (siw *ServerInterfaceWrapper) GetLabelNoExplodeArray(w http.ResponseWriter,
 	var handler = http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		resp := siw.Handler.GetLabelNoExplodeArray(w, r, param)
 		if resp != nil {
+			if resp, ok := resp.(Response); ok && resp.Body == nil {
+				w.WriteHeader(resp.Code)
+				return
+			}
+
 			render.Render(w, r, resp)
 		}
 	})
@@ -596,6 +626,11 @@ func (siw *ServerInterfaceWrapper) GetLabelNoExplodeObject(w http.ResponseWriter
 	var handler = http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		resp := siw.Handler.GetLabelNoExplodeObject(w, r, param)
 		if resp != nil {
+			if resp, ok := resp.(Response); ok && resp.Body == nil {
+				w.WriteHeader(resp.Code)
+				return
+			}
+
 			render.Render(w, r, resp)
 		}
 	})
@@ -618,6 +653,11 @@ func (siw *ServerInterfaceWrapper) GetMatrixExplodeArray(w http.ResponseWriter, 
 	var handler = http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		resp := siw.Handler.GetMatrixExplodeArray(w, r, id)
 		if resp != nil {
+			if resp, ok := resp.(Response); ok && resp.Body == nil {
+				w.WriteHeader(resp.Code)
+				return
+			}
+
 			render.Render(w, r, resp)
 		}
 	})
@@ -640,6 +680,11 @@ func (siw *ServerInterfaceWrapper) GetMatrixExplodeObject(w http.ResponseWriter,
 	var handler = http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		resp := siw.Handler.GetMatrixExplodeObject(w, r, id)
 		if resp != nil {
+			if resp, ok := resp.(Response); ok && resp.Body == nil {
+				w.WriteHeader(resp.Code)
+				return
+			}
+
 			render.Render(w, r, resp)
 		}
 	})
@@ -662,6 +707,11 @@ func (siw *ServerInterfaceWrapper) GetMatrixNoExplodeArray(w http.ResponseWriter
 	var handler = http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		resp := siw.Handler.GetMatrixNoExplodeArray(w, r, id)
 		if resp != nil {
+			if resp, ok := resp.(Response); ok && resp.Body == nil {
+				w.WriteHeader(resp.Code)
+				return
+			}
+
 			render.Render(w, r, resp)
 		}
 	})
@@ -684,6 +734,11 @@ func (siw *ServerInterfaceWrapper) GetMatrixNoExplodeObject(w http.ResponseWrite
 	var handler = http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		resp := siw.Handler.GetMatrixNoExplodeObject(w, r, id)
 		if resp != nil {
+			if resp, ok := resp.(Response); ok && resp.Body == nil {
+				w.WriteHeader(resp.Code)
+				return
+			}
+
 			render.Render(w, r, resp)
 		}
 	})
@@ -703,6 +758,11 @@ func (siw *ServerInterfaceWrapper) GetPassThrough(w http.ResponseWriter, r *http
 	var handler = http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		resp := siw.Handler.GetPassThrough(w, r, param)
 		if resp != nil {
+			if resp, ok := resp.(Response); ok && resp.Body == nil {
+				w.WriteHeader(resp.Code)
+				return
+			}
+
 			render.Render(w, r, resp)
 		}
 	})
@@ -728,6 +788,11 @@ func (siw *ServerInterfaceWrapper) GetDeepObject(w http.ResponseWriter, r *http.
 	var handler = http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		resp := siw.Handler.GetDeepObject(w, r, params)
 		if resp != nil {
+			if resp, ok := resp.(Response); ok && resp.Body == nil {
+				w.WriteHeader(resp.Code)
+				return
+			}
+
 			render.Render(w, r, resp)
 		}
 	})
@@ -822,6 +887,11 @@ func (siw *ServerInterfaceWrapper) GetQueryForm(w http.ResponseWriter, r *http.R
 	var handler = http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		resp := siw.Handler.GetQueryForm(w, r, params)
 		if resp != nil {
+			if resp, ok := resp.(Response); ok && resp.Body == nil {
+				w.WriteHeader(resp.Code)
+				return
+			}
+
 			render.Render(w, r, resp)
 		}
 	})
@@ -844,6 +914,11 @@ func (siw *ServerInterfaceWrapper) GetSimpleExplodeArray(w http.ResponseWriter, 
 	var handler = http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		resp := siw.Handler.GetSimpleExplodeArray(w, r, param)
 		if resp != nil {
+			if resp, ok := resp.(Response); ok && resp.Body == nil {
+				w.WriteHeader(resp.Code)
+				return
+			}
+
 			render.Render(w, r, resp)
 		}
 	})
@@ -866,6 +941,11 @@ func (siw *ServerInterfaceWrapper) GetSimpleExplodeObject(w http.ResponseWriter,
 	var handler = http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		resp := siw.Handler.GetSimpleExplodeObject(w, r, param)
 		if resp != nil {
+			if resp, ok := resp.(Response); ok && resp.Body == nil {
+				w.WriteHeader(resp.Code)
+				return
+			}
+
 			render.Render(w, r, resp)
 		}
 	})
@@ -888,6 +968,11 @@ func (siw *ServerInterfaceWrapper) GetSimpleNoExplodeArray(w http.ResponseWriter
 	var handler = http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		resp := siw.Handler.GetSimpleNoExplodeArray(w, r, param)
 		if resp != nil {
+			if resp, ok := resp.(Response); ok && resp.Body == nil {
+				w.WriteHeader(resp.Code)
+				return
+			}
+
 			render.Render(w, r, resp)
 		}
 	})
@@ -910,6 +995,11 @@ func (siw *ServerInterfaceWrapper) GetSimpleNoExplodeObject(w http.ResponseWrite
 	var handler = http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		resp := siw.Handler.GetSimpleNoExplodeObject(w, r, param)
 		if resp != nil {
+			if resp, ok := resp.(Response); ok && resp.Body == nil {
+				w.WriteHeader(resp.Code)
+				return
+			}
+
 			render.Render(w, r, resp)
 		}
 	})
@@ -932,6 +1022,11 @@ func (siw *ServerInterfaceWrapper) GetSimplePrimitive(w http.ResponseWriter, r *
 	var handler = http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		resp := siw.Handler.GetSimplePrimitive(w, r, param)
 		if resp != nil {
+			if resp, ok := resp.(Response); ok && resp.Body == nil {
+				w.WriteHeader(resp.Code)
+				return
+			}
+
 			render.Render(w, r, resp)
 		}
 	})
@@ -951,6 +1046,11 @@ func (siw *ServerInterfaceWrapper) GetStartingWithNumber(w http.ResponseWriter, 
 	var handler = http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		resp := siw.Handler.GetStartingWithNumber(w, r, n1param)
 		if resp != nil {
+			if resp, ok := resp.(Response); ok && resp.Body == nil {
+				w.WriteHeader(resp.Code)
+				return
+			}
+
 			render.Render(w, r, resp)
 		}
 	})

--- a/internal/test/parameters/parameters.gen.go
+++ b/internal/test/parameters/parameters.gen.go
@@ -124,19 +124,29 @@ type GetQueryFormParams struct {
 	N1s *string `json:"1s,omitempty"`
 }
 
+// Responser is an interface for responding to a request.
+type Responser interface {
+	Response() *Response
+}
+
 // Response is a common response struct for all the API calls.
 // A Response object may be instantiated via functions for specific operation responses.
 // It may also be instantiated directly, for the purpose of responding with a single status code.
 type Response struct {
-	body        interface{}
+	Body        interface{}
 	Code        int
-	contentType string
+	ContentType string
+}
+
+// Response implements the Responser interface.
+func (r *Response) Response() *Response {
+	return r
 }
 
 // Render implements the render.Renderer interface. It sets the Content-Type header
 // and status code based on the response definition.
 func (resp *Response) Render(w http.ResponseWriter, r *http.Request) error {
-	w.Header().Set("Content-Type", resp.contentType)
+	w.Header().Set("Content-Type", resp.ContentType)
 	render.Status(r, resp.Code)
 	return nil
 }
@@ -148,85 +158,85 @@ func (resp *Response) Status(code int) *Response {
 }
 
 // ContentType is a builder method to override the default content type for a response.
-func (resp *Response) ContentType(contentType string) *Response {
-	resp.contentType = contentType
+func (resp *Response) ContentTyp(contentType string) *Response {
+	resp.ContentType = contentType
 	return resp
 }
 
 // MarshalJSON implements the json.Marshaler interface.
 // This is used to only marshal the body of the response.
 func (resp *Response) MarshalJSON() ([]byte, error) {
-	return json.Marshal(resp.body)
+	return json.Marshal(resp.Body)
 }
 
 // MarshalXML implements the xml.Marshaler interface.
 // This is used to only marshal the body of the response.
 func (resp *Response) MarshalXML(e *xml.Encoder, start xml.StartElement) error {
-	return e.Encode(resp.body)
+	return e.Encode(resp.Body)
 }
 
 // ServerInterface represents all server handlers.
 type ServerInterface interface {
 
 	// (GET /contentObject/{param})
-	GetContentObject(w http.ResponseWriter, r *http.Request, param ComplexObject) *Response
+	GetContentObject(w http.ResponseWriter, r *http.Request, param ComplexObject) Responser
 
 	// (GET /cookie)
-	GetCookie(w http.ResponseWriter, r *http.Request, params GetCookieParams) *Response
+	GetCookie(w http.ResponseWriter, r *http.Request, params GetCookieParams) Responser
 
 	// (GET /header)
-	GetHeader(w http.ResponseWriter, r *http.Request, params GetHeaderParams) *Response
+	GetHeader(w http.ResponseWriter, r *http.Request, params GetHeaderParams) Responser
 
 	// (GET /labelExplodeArray/{.param*})
-	GetLabelExplodeArray(w http.ResponseWriter, r *http.Request, param []int32) *Response
+	GetLabelExplodeArray(w http.ResponseWriter, r *http.Request, param []int32) Responser
 
 	// (GET /labelExplodeObject/{.param*})
-	GetLabelExplodeObject(w http.ResponseWriter, r *http.Request, param Object) *Response
+	GetLabelExplodeObject(w http.ResponseWriter, r *http.Request, param Object) Responser
 
 	// (GET /labelNoExplodeArray/{.param})
-	GetLabelNoExplodeArray(w http.ResponseWriter, r *http.Request, param []int32) *Response
+	GetLabelNoExplodeArray(w http.ResponseWriter, r *http.Request, param []int32) Responser
 
 	// (GET /labelNoExplodeObject/{.param})
-	GetLabelNoExplodeObject(w http.ResponseWriter, r *http.Request, param Object) *Response
+	GetLabelNoExplodeObject(w http.ResponseWriter, r *http.Request, param Object) Responser
 
 	// (GET /matrixExplodeArray/{.id*})
-	GetMatrixExplodeArray(w http.ResponseWriter, r *http.Request, id []int32) *Response
+	GetMatrixExplodeArray(w http.ResponseWriter, r *http.Request, id []int32) Responser
 
 	// (GET /matrixExplodeObject/{.id*})
-	GetMatrixExplodeObject(w http.ResponseWriter, r *http.Request, id Object) *Response
+	GetMatrixExplodeObject(w http.ResponseWriter, r *http.Request, id Object) Responser
 
 	// (GET /matrixNoExplodeArray/{.id})
-	GetMatrixNoExplodeArray(w http.ResponseWriter, r *http.Request, id []int32) *Response
+	GetMatrixNoExplodeArray(w http.ResponseWriter, r *http.Request, id []int32) Responser
 
 	// (GET /matrixNoExplodeObject/{.id})
-	GetMatrixNoExplodeObject(w http.ResponseWriter, r *http.Request, id Object) *Response
+	GetMatrixNoExplodeObject(w http.ResponseWriter, r *http.Request, id Object) Responser
 
 	// (GET /passThrough/{param})
-	GetPassThrough(w http.ResponseWriter, r *http.Request, param string) *Response
+	GetPassThrough(w http.ResponseWriter, r *http.Request, param string) Responser
 
 	// (GET /queryDeepObject)
-	GetDeepObject(w http.ResponseWriter, r *http.Request, params GetDeepObjectParams) *Response
+	GetDeepObject(w http.ResponseWriter, r *http.Request, params GetDeepObjectParams) Responser
 
 	// (GET /queryForm)
-	GetQueryForm(w http.ResponseWriter, r *http.Request, params GetQueryFormParams) *Response
+	GetQueryForm(w http.ResponseWriter, r *http.Request, params GetQueryFormParams) Responser
 
 	// (GET /simpleExplodeArray/{param*})
-	GetSimpleExplodeArray(w http.ResponseWriter, r *http.Request, param []int32) *Response
+	GetSimpleExplodeArray(w http.ResponseWriter, r *http.Request, param []int32) Responser
 
 	// (GET /simpleExplodeObject/{param*})
-	GetSimpleExplodeObject(w http.ResponseWriter, r *http.Request, param Object) *Response
+	GetSimpleExplodeObject(w http.ResponseWriter, r *http.Request, param Object) Responser
 
 	// (GET /simpleNoExplodeArray/{param})
-	GetSimpleNoExplodeArray(w http.ResponseWriter, r *http.Request, param []int32) *Response
+	GetSimpleNoExplodeArray(w http.ResponseWriter, r *http.Request, param []int32) Responser
 
 	// (GET /simpleNoExplodeObject/{param})
-	GetSimpleNoExplodeObject(w http.ResponseWriter, r *http.Request, param Object) *Response
+	GetSimpleNoExplodeObject(w http.ResponseWriter, r *http.Request, param Object) Responser
 
 	// (GET /simplePrimitive/{param})
-	GetSimplePrimitive(w http.ResponseWriter, r *http.Request, param int32) *Response
+	GetSimplePrimitive(w http.ResponseWriter, r *http.Request, param int32) Responser
 
 	// (GET /startingWithNumber/{1param})
-	GetStartingWithNumber(w http.ResponseWriter, r *http.Request, n1param string) *Response
+	GetStartingWithNumber(w http.ResponseWriter, r *http.Request, n1param string) Responser
 }
 
 // ServerInterfaceWrapper converts contexts to parameters.
@@ -251,10 +261,11 @@ func (siw *ServerInterfaceWrapper) GetContentObject(w http.ResponseWriter, r *ht
 	var handler = http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		resp := siw.Handler.GetContentObject(w, r, param)
 		if resp != nil {
-			if resp.body != nil {
-				render.Render(w, r, resp)
+			rsp := resp.Response()
+			if rsp.Body != nil {
+				render.Render(w, r, rsp)
 			} else {
-				w.WriteHeader(resp.Code)
+				w.WriteHeader(rsp.Code)
 			}
 		}
 	})
@@ -361,10 +372,11 @@ func (siw *ServerInterfaceWrapper) GetCookie(w http.ResponseWriter, r *http.Requ
 	var handler = http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		resp := siw.Handler.GetCookie(w, r, params)
 		if resp != nil {
-			if resp.body != nil {
-				render.Render(w, r, resp)
+			rsp := resp.Response()
+			if rsp.Body != nil {
+				render.Render(w, r, rsp)
 			} else {
-				w.WriteHeader(resp.Code)
+				w.WriteHeader(rsp.Code)
 			}
 		}
 	})
@@ -528,10 +540,11 @@ func (siw *ServerInterfaceWrapper) GetHeader(w http.ResponseWriter, r *http.Requ
 	var handler = http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		resp := siw.Handler.GetHeader(w, r, params)
 		if resp != nil {
-			if resp.body != nil {
-				render.Render(w, r, resp)
+			rsp := resp.Response()
+			if rsp.Body != nil {
+				render.Render(w, r, rsp)
 			} else {
-				w.WriteHeader(resp.Code)
+				w.WriteHeader(rsp.Code)
 			}
 		}
 	})
@@ -554,10 +567,11 @@ func (siw *ServerInterfaceWrapper) GetLabelExplodeArray(w http.ResponseWriter, r
 	var handler = http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		resp := siw.Handler.GetLabelExplodeArray(w, r, param)
 		if resp != nil {
-			if resp.body != nil {
-				render.Render(w, r, resp)
+			rsp := resp.Response()
+			if rsp.Body != nil {
+				render.Render(w, r, rsp)
 			} else {
-				w.WriteHeader(resp.Code)
+				w.WriteHeader(rsp.Code)
 			}
 		}
 	})
@@ -580,10 +594,11 @@ func (siw *ServerInterfaceWrapper) GetLabelExplodeObject(w http.ResponseWriter, 
 	var handler = http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		resp := siw.Handler.GetLabelExplodeObject(w, r, param)
 		if resp != nil {
-			if resp.body != nil {
-				render.Render(w, r, resp)
+			rsp := resp.Response()
+			if rsp.Body != nil {
+				render.Render(w, r, rsp)
 			} else {
-				w.WriteHeader(resp.Code)
+				w.WriteHeader(rsp.Code)
 			}
 		}
 	})
@@ -606,10 +621,11 @@ func (siw *ServerInterfaceWrapper) GetLabelNoExplodeArray(w http.ResponseWriter,
 	var handler = http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		resp := siw.Handler.GetLabelNoExplodeArray(w, r, param)
 		if resp != nil {
-			if resp.body != nil {
-				render.Render(w, r, resp)
+			rsp := resp.Response()
+			if rsp.Body != nil {
+				render.Render(w, r, rsp)
 			} else {
-				w.WriteHeader(resp.Code)
+				w.WriteHeader(rsp.Code)
 			}
 		}
 	})
@@ -632,10 +648,11 @@ func (siw *ServerInterfaceWrapper) GetLabelNoExplodeObject(w http.ResponseWriter
 	var handler = http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		resp := siw.Handler.GetLabelNoExplodeObject(w, r, param)
 		if resp != nil {
-			if resp.body != nil {
-				render.Render(w, r, resp)
+			rsp := resp.Response()
+			if rsp.Body != nil {
+				render.Render(w, r, rsp)
 			} else {
-				w.WriteHeader(resp.Code)
+				w.WriteHeader(rsp.Code)
 			}
 		}
 	})
@@ -658,10 +675,11 @@ func (siw *ServerInterfaceWrapper) GetMatrixExplodeArray(w http.ResponseWriter, 
 	var handler = http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		resp := siw.Handler.GetMatrixExplodeArray(w, r, id)
 		if resp != nil {
-			if resp.body != nil {
-				render.Render(w, r, resp)
+			rsp := resp.Response()
+			if rsp.Body != nil {
+				render.Render(w, r, rsp)
 			} else {
-				w.WriteHeader(resp.Code)
+				w.WriteHeader(rsp.Code)
 			}
 		}
 	})
@@ -684,10 +702,11 @@ func (siw *ServerInterfaceWrapper) GetMatrixExplodeObject(w http.ResponseWriter,
 	var handler = http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		resp := siw.Handler.GetMatrixExplodeObject(w, r, id)
 		if resp != nil {
-			if resp.body != nil {
-				render.Render(w, r, resp)
+			rsp := resp.Response()
+			if rsp.Body != nil {
+				render.Render(w, r, rsp)
 			} else {
-				w.WriteHeader(resp.Code)
+				w.WriteHeader(rsp.Code)
 			}
 		}
 	})
@@ -710,10 +729,11 @@ func (siw *ServerInterfaceWrapper) GetMatrixNoExplodeArray(w http.ResponseWriter
 	var handler = http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		resp := siw.Handler.GetMatrixNoExplodeArray(w, r, id)
 		if resp != nil {
-			if resp.body != nil {
-				render.Render(w, r, resp)
+			rsp := resp.Response()
+			if rsp.Body != nil {
+				render.Render(w, r, rsp)
 			} else {
-				w.WriteHeader(resp.Code)
+				w.WriteHeader(rsp.Code)
 			}
 		}
 	})
@@ -736,10 +756,11 @@ func (siw *ServerInterfaceWrapper) GetMatrixNoExplodeObject(w http.ResponseWrite
 	var handler = http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		resp := siw.Handler.GetMatrixNoExplodeObject(w, r, id)
 		if resp != nil {
-			if resp.body != nil {
-				render.Render(w, r, resp)
+			rsp := resp.Response()
+			if rsp.Body != nil {
+				render.Render(w, r, rsp)
 			} else {
-				w.WriteHeader(resp.Code)
+				w.WriteHeader(rsp.Code)
 			}
 		}
 	})
@@ -759,10 +780,11 @@ func (siw *ServerInterfaceWrapper) GetPassThrough(w http.ResponseWriter, r *http
 	var handler = http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		resp := siw.Handler.GetPassThrough(w, r, param)
 		if resp != nil {
-			if resp.body != nil {
-				render.Render(w, r, resp)
+			rsp := resp.Response()
+			if rsp.Body != nil {
+				render.Render(w, r, rsp)
 			} else {
-				w.WriteHeader(resp.Code)
+				w.WriteHeader(rsp.Code)
 			}
 		}
 	})
@@ -788,10 +810,11 @@ func (siw *ServerInterfaceWrapper) GetDeepObject(w http.ResponseWriter, r *http.
 	var handler = http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		resp := siw.Handler.GetDeepObject(w, r, params)
 		if resp != nil {
-			if resp.body != nil {
-				render.Render(w, r, resp)
+			rsp := resp.Response()
+			if rsp.Body != nil {
+				render.Render(w, r, rsp)
 			} else {
-				w.WriteHeader(resp.Code)
+				w.WriteHeader(rsp.Code)
 			}
 		}
 	})
@@ -886,10 +909,11 @@ func (siw *ServerInterfaceWrapper) GetQueryForm(w http.ResponseWriter, r *http.R
 	var handler = http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		resp := siw.Handler.GetQueryForm(w, r, params)
 		if resp != nil {
-			if resp.body != nil {
-				render.Render(w, r, resp)
+			rsp := resp.Response()
+			if rsp.Body != nil {
+				render.Render(w, r, rsp)
 			} else {
-				w.WriteHeader(resp.Code)
+				w.WriteHeader(rsp.Code)
 			}
 		}
 	})
@@ -912,10 +936,11 @@ func (siw *ServerInterfaceWrapper) GetSimpleExplodeArray(w http.ResponseWriter, 
 	var handler = http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		resp := siw.Handler.GetSimpleExplodeArray(w, r, param)
 		if resp != nil {
-			if resp.body != nil {
-				render.Render(w, r, resp)
+			rsp := resp.Response()
+			if rsp.Body != nil {
+				render.Render(w, r, rsp)
 			} else {
-				w.WriteHeader(resp.Code)
+				w.WriteHeader(rsp.Code)
 			}
 		}
 	})
@@ -938,10 +963,11 @@ func (siw *ServerInterfaceWrapper) GetSimpleExplodeObject(w http.ResponseWriter,
 	var handler = http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		resp := siw.Handler.GetSimpleExplodeObject(w, r, param)
 		if resp != nil {
-			if resp.body != nil {
-				render.Render(w, r, resp)
+			rsp := resp.Response()
+			if rsp.Body != nil {
+				render.Render(w, r, rsp)
 			} else {
-				w.WriteHeader(resp.Code)
+				w.WriteHeader(rsp.Code)
 			}
 		}
 	})
@@ -964,10 +990,11 @@ func (siw *ServerInterfaceWrapper) GetSimpleNoExplodeArray(w http.ResponseWriter
 	var handler = http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		resp := siw.Handler.GetSimpleNoExplodeArray(w, r, param)
 		if resp != nil {
-			if resp.body != nil {
-				render.Render(w, r, resp)
+			rsp := resp.Response()
+			if rsp.Body != nil {
+				render.Render(w, r, rsp)
 			} else {
-				w.WriteHeader(resp.Code)
+				w.WriteHeader(rsp.Code)
 			}
 		}
 	})
@@ -990,10 +1017,11 @@ func (siw *ServerInterfaceWrapper) GetSimpleNoExplodeObject(w http.ResponseWrite
 	var handler = http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		resp := siw.Handler.GetSimpleNoExplodeObject(w, r, param)
 		if resp != nil {
-			if resp.body != nil {
-				render.Render(w, r, resp)
+			rsp := resp.Response()
+			if rsp.Body != nil {
+				render.Render(w, r, rsp)
 			} else {
-				w.WriteHeader(resp.Code)
+				w.WriteHeader(rsp.Code)
 			}
 		}
 	})
@@ -1016,10 +1044,11 @@ func (siw *ServerInterfaceWrapper) GetSimplePrimitive(w http.ResponseWriter, r *
 	var handler = http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		resp := siw.Handler.GetSimplePrimitive(w, r, param)
 		if resp != nil {
-			if resp.body != nil {
-				render.Render(w, r, resp)
+			rsp := resp.Response()
+			if rsp.Body != nil {
+				render.Render(w, r, rsp)
 			} else {
-				w.WriteHeader(resp.Code)
+				w.WriteHeader(rsp.Code)
 			}
 		}
 	})
@@ -1039,10 +1068,11 @@ func (siw *ServerInterfaceWrapper) GetStartingWithNumber(w http.ResponseWriter, 
 	var handler = http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		resp := siw.Handler.GetStartingWithNumber(w, r, n1param)
 		if resp != nil {
-			if resp.body != nil {
-				render.Render(w, r, resp)
+			rsp := resp.Response()
+			if rsp.Body != nil {
+				render.Render(w, r, rsp)
 			} else {
-				w.WriteHeader(resp.Code)
+				w.WriteHeader(rsp.Code)
 			}
 		}
 	})

--- a/internal/test/parameters/parameters.gen.go
+++ b/internal/test/parameters/parameters.gen.go
@@ -124,11 +124,6 @@ type GetQueryFormParams struct {
 	N1s *string `json:"1s,omitempty"`
 }
 
-// Responser is an interface for responding to a request.
-type Responser interface {
-	Response() *Response
-}
-
 // Response is a common response struct for all the API calls.
 // A Response object may be instantiated via functions for specific operation responses.
 // It may also be instantiated directly, for the purpose of responding with a single status code.
@@ -138,29 +133,12 @@ type Response struct {
 	ContentType string
 }
 
-// Response implements the Responser interface.
-func (r *Response) Response() *Response {
-	return r
-}
-
 // Render implements the render.Renderer interface. It sets the Content-Type header
 // and status code based on the response definition.
 func (resp *Response) Render(w http.ResponseWriter, r *http.Request) error {
 	w.Header().Set("Content-Type", resp.ContentType)
 	render.Status(r, resp.Code)
 	return nil
-}
-
-// Status is a builder method to override the default status code for a response.
-func (resp *Response) Status(code int) *Response {
-	resp.Code = code
-	return resp
-}
-
-// ContentType is a builder method to override the default content type for a response.
-func (resp *Response) ContentTyp(contentType string) *Response {
-	resp.ContentType = contentType
-	return resp
 }
 
 // MarshalJSON implements the json.Marshaler interface.
@@ -179,64 +157,64 @@ func (resp *Response) MarshalXML(e *xml.Encoder, start xml.StartElement) error {
 type ServerInterface interface {
 
 	// (GET /contentObject/{param})
-	GetContentObject(w http.ResponseWriter, r *http.Request, param ComplexObject) Responser
+	GetContentObject(w http.ResponseWriter, r *http.Request, param ComplexObject) render.Renderer
 
 	// (GET /cookie)
-	GetCookie(w http.ResponseWriter, r *http.Request, params GetCookieParams) Responser
+	GetCookie(w http.ResponseWriter, r *http.Request, params GetCookieParams) render.Renderer
 
 	// (GET /header)
-	GetHeader(w http.ResponseWriter, r *http.Request, params GetHeaderParams) Responser
+	GetHeader(w http.ResponseWriter, r *http.Request, params GetHeaderParams) render.Renderer
 
 	// (GET /labelExplodeArray/{.param*})
-	GetLabelExplodeArray(w http.ResponseWriter, r *http.Request, param []int32) Responser
+	GetLabelExplodeArray(w http.ResponseWriter, r *http.Request, param []int32) render.Renderer
 
 	// (GET /labelExplodeObject/{.param*})
-	GetLabelExplodeObject(w http.ResponseWriter, r *http.Request, param Object) Responser
+	GetLabelExplodeObject(w http.ResponseWriter, r *http.Request, param Object) render.Renderer
 
 	// (GET /labelNoExplodeArray/{.param})
-	GetLabelNoExplodeArray(w http.ResponseWriter, r *http.Request, param []int32) Responser
+	GetLabelNoExplodeArray(w http.ResponseWriter, r *http.Request, param []int32) render.Renderer
 
 	// (GET /labelNoExplodeObject/{.param})
-	GetLabelNoExplodeObject(w http.ResponseWriter, r *http.Request, param Object) Responser
+	GetLabelNoExplodeObject(w http.ResponseWriter, r *http.Request, param Object) render.Renderer
 
 	// (GET /matrixExplodeArray/{.id*})
-	GetMatrixExplodeArray(w http.ResponseWriter, r *http.Request, id []int32) Responser
+	GetMatrixExplodeArray(w http.ResponseWriter, r *http.Request, id []int32) render.Renderer
 
 	// (GET /matrixExplodeObject/{.id*})
-	GetMatrixExplodeObject(w http.ResponseWriter, r *http.Request, id Object) Responser
+	GetMatrixExplodeObject(w http.ResponseWriter, r *http.Request, id Object) render.Renderer
 
 	// (GET /matrixNoExplodeArray/{.id})
-	GetMatrixNoExplodeArray(w http.ResponseWriter, r *http.Request, id []int32) Responser
+	GetMatrixNoExplodeArray(w http.ResponseWriter, r *http.Request, id []int32) render.Renderer
 
 	// (GET /matrixNoExplodeObject/{.id})
-	GetMatrixNoExplodeObject(w http.ResponseWriter, r *http.Request, id Object) Responser
+	GetMatrixNoExplodeObject(w http.ResponseWriter, r *http.Request, id Object) render.Renderer
 
 	// (GET /passThrough/{param})
-	GetPassThrough(w http.ResponseWriter, r *http.Request, param string) Responser
+	GetPassThrough(w http.ResponseWriter, r *http.Request, param string) render.Renderer
 
 	// (GET /queryDeepObject)
-	GetDeepObject(w http.ResponseWriter, r *http.Request, params GetDeepObjectParams) Responser
+	GetDeepObject(w http.ResponseWriter, r *http.Request, params GetDeepObjectParams) render.Renderer
 
 	// (GET /queryForm)
-	GetQueryForm(w http.ResponseWriter, r *http.Request, params GetQueryFormParams) Responser
+	GetQueryForm(w http.ResponseWriter, r *http.Request, params GetQueryFormParams) render.Renderer
 
 	// (GET /simpleExplodeArray/{param*})
-	GetSimpleExplodeArray(w http.ResponseWriter, r *http.Request, param []int32) Responser
+	GetSimpleExplodeArray(w http.ResponseWriter, r *http.Request, param []int32) render.Renderer
 
 	// (GET /simpleExplodeObject/{param*})
-	GetSimpleExplodeObject(w http.ResponseWriter, r *http.Request, param Object) Responser
+	GetSimpleExplodeObject(w http.ResponseWriter, r *http.Request, param Object) render.Renderer
 
 	// (GET /simpleNoExplodeArray/{param})
-	GetSimpleNoExplodeArray(w http.ResponseWriter, r *http.Request, param []int32) Responser
+	GetSimpleNoExplodeArray(w http.ResponseWriter, r *http.Request, param []int32) render.Renderer
 
 	// (GET /simpleNoExplodeObject/{param})
-	GetSimpleNoExplodeObject(w http.ResponseWriter, r *http.Request, param Object) Responser
+	GetSimpleNoExplodeObject(w http.ResponseWriter, r *http.Request, param Object) render.Renderer
 
 	// (GET /simplePrimitive/{param})
-	GetSimplePrimitive(w http.ResponseWriter, r *http.Request, param int32) Responser
+	GetSimplePrimitive(w http.ResponseWriter, r *http.Request, param int32) render.Renderer
 
 	// (GET /startingWithNumber/{1param})
-	GetStartingWithNumber(w http.ResponseWriter, r *http.Request, n1param string) Responser
+	GetStartingWithNumber(w http.ResponseWriter, r *http.Request, n1param string) render.Renderer
 }
 
 // ServerInterfaceWrapper converts contexts to parameters.
@@ -261,12 +239,7 @@ func (siw *ServerInterfaceWrapper) GetContentObject(w http.ResponseWriter, r *ht
 	var handler = http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		resp := siw.Handler.GetContentObject(w, r, param)
 		if resp != nil {
-			rsp := resp.Response()
-			if rsp.Body != nil {
-				render.Render(w, r, rsp)
-			} else {
-				w.WriteHeader(rsp.Code)
-			}
+			render.Render(w, r, resp)
 		}
 	})
 
@@ -372,12 +345,7 @@ func (siw *ServerInterfaceWrapper) GetCookie(w http.ResponseWriter, r *http.Requ
 	var handler = http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		resp := siw.Handler.GetCookie(w, r, params)
 		if resp != nil {
-			rsp := resp.Response()
-			if rsp.Body != nil {
-				render.Render(w, r, rsp)
-			} else {
-				w.WriteHeader(rsp.Code)
-			}
+			render.Render(w, r, resp)
 		}
 	})
 
@@ -540,12 +508,7 @@ func (siw *ServerInterfaceWrapper) GetHeader(w http.ResponseWriter, r *http.Requ
 	var handler = http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		resp := siw.Handler.GetHeader(w, r, params)
 		if resp != nil {
-			rsp := resp.Response()
-			if rsp.Body != nil {
-				render.Render(w, r, rsp)
-			} else {
-				w.WriteHeader(rsp.Code)
-			}
+			render.Render(w, r, resp)
 		}
 	})
 
@@ -567,12 +530,7 @@ func (siw *ServerInterfaceWrapper) GetLabelExplodeArray(w http.ResponseWriter, r
 	var handler = http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		resp := siw.Handler.GetLabelExplodeArray(w, r, param)
 		if resp != nil {
-			rsp := resp.Response()
-			if rsp.Body != nil {
-				render.Render(w, r, rsp)
-			} else {
-				w.WriteHeader(rsp.Code)
-			}
+			render.Render(w, r, resp)
 		}
 	})
 
@@ -594,12 +552,7 @@ func (siw *ServerInterfaceWrapper) GetLabelExplodeObject(w http.ResponseWriter, 
 	var handler = http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		resp := siw.Handler.GetLabelExplodeObject(w, r, param)
 		if resp != nil {
-			rsp := resp.Response()
-			if rsp.Body != nil {
-				render.Render(w, r, rsp)
-			} else {
-				w.WriteHeader(rsp.Code)
-			}
+			render.Render(w, r, resp)
 		}
 	})
 
@@ -621,12 +574,7 @@ func (siw *ServerInterfaceWrapper) GetLabelNoExplodeArray(w http.ResponseWriter,
 	var handler = http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		resp := siw.Handler.GetLabelNoExplodeArray(w, r, param)
 		if resp != nil {
-			rsp := resp.Response()
-			if rsp.Body != nil {
-				render.Render(w, r, rsp)
-			} else {
-				w.WriteHeader(rsp.Code)
-			}
+			render.Render(w, r, resp)
 		}
 	})
 
@@ -648,12 +596,7 @@ func (siw *ServerInterfaceWrapper) GetLabelNoExplodeObject(w http.ResponseWriter
 	var handler = http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		resp := siw.Handler.GetLabelNoExplodeObject(w, r, param)
 		if resp != nil {
-			rsp := resp.Response()
-			if rsp.Body != nil {
-				render.Render(w, r, rsp)
-			} else {
-				w.WriteHeader(rsp.Code)
-			}
+			render.Render(w, r, resp)
 		}
 	})
 
@@ -675,12 +618,7 @@ func (siw *ServerInterfaceWrapper) GetMatrixExplodeArray(w http.ResponseWriter, 
 	var handler = http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		resp := siw.Handler.GetMatrixExplodeArray(w, r, id)
 		if resp != nil {
-			rsp := resp.Response()
-			if rsp.Body != nil {
-				render.Render(w, r, rsp)
-			} else {
-				w.WriteHeader(rsp.Code)
-			}
+			render.Render(w, r, resp)
 		}
 	})
 
@@ -702,12 +640,7 @@ func (siw *ServerInterfaceWrapper) GetMatrixExplodeObject(w http.ResponseWriter,
 	var handler = http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		resp := siw.Handler.GetMatrixExplodeObject(w, r, id)
 		if resp != nil {
-			rsp := resp.Response()
-			if rsp.Body != nil {
-				render.Render(w, r, rsp)
-			} else {
-				w.WriteHeader(rsp.Code)
-			}
+			render.Render(w, r, resp)
 		}
 	})
 
@@ -729,12 +662,7 @@ func (siw *ServerInterfaceWrapper) GetMatrixNoExplodeArray(w http.ResponseWriter
 	var handler = http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		resp := siw.Handler.GetMatrixNoExplodeArray(w, r, id)
 		if resp != nil {
-			rsp := resp.Response()
-			if rsp.Body != nil {
-				render.Render(w, r, rsp)
-			} else {
-				w.WriteHeader(rsp.Code)
-			}
+			render.Render(w, r, resp)
 		}
 	})
 
@@ -756,12 +684,7 @@ func (siw *ServerInterfaceWrapper) GetMatrixNoExplodeObject(w http.ResponseWrite
 	var handler = http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		resp := siw.Handler.GetMatrixNoExplodeObject(w, r, id)
 		if resp != nil {
-			rsp := resp.Response()
-			if rsp.Body != nil {
-				render.Render(w, r, rsp)
-			} else {
-				w.WriteHeader(rsp.Code)
-			}
+			render.Render(w, r, resp)
 		}
 	})
 
@@ -780,12 +703,7 @@ func (siw *ServerInterfaceWrapper) GetPassThrough(w http.ResponseWriter, r *http
 	var handler = http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		resp := siw.Handler.GetPassThrough(w, r, param)
 		if resp != nil {
-			rsp := resp.Response()
-			if rsp.Body != nil {
-				render.Render(w, r, rsp)
-			} else {
-				w.WriteHeader(rsp.Code)
-			}
+			render.Render(w, r, resp)
 		}
 	})
 
@@ -810,12 +728,7 @@ func (siw *ServerInterfaceWrapper) GetDeepObject(w http.ResponseWriter, r *http.
 	var handler = http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		resp := siw.Handler.GetDeepObject(w, r, params)
 		if resp != nil {
-			rsp := resp.Response()
-			if rsp.Body != nil {
-				render.Render(w, r, rsp)
-			} else {
-				w.WriteHeader(rsp.Code)
-			}
+			render.Render(w, r, resp)
 		}
 	})
 
@@ -909,12 +822,7 @@ func (siw *ServerInterfaceWrapper) GetQueryForm(w http.ResponseWriter, r *http.R
 	var handler = http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		resp := siw.Handler.GetQueryForm(w, r, params)
 		if resp != nil {
-			rsp := resp.Response()
-			if rsp.Body != nil {
-				render.Render(w, r, rsp)
-			} else {
-				w.WriteHeader(rsp.Code)
-			}
+			render.Render(w, r, resp)
 		}
 	})
 
@@ -936,12 +844,7 @@ func (siw *ServerInterfaceWrapper) GetSimpleExplodeArray(w http.ResponseWriter, 
 	var handler = http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		resp := siw.Handler.GetSimpleExplodeArray(w, r, param)
 		if resp != nil {
-			rsp := resp.Response()
-			if rsp.Body != nil {
-				render.Render(w, r, rsp)
-			} else {
-				w.WriteHeader(rsp.Code)
-			}
+			render.Render(w, r, resp)
 		}
 	})
 
@@ -963,12 +866,7 @@ func (siw *ServerInterfaceWrapper) GetSimpleExplodeObject(w http.ResponseWriter,
 	var handler = http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		resp := siw.Handler.GetSimpleExplodeObject(w, r, param)
 		if resp != nil {
-			rsp := resp.Response()
-			if rsp.Body != nil {
-				render.Render(w, r, rsp)
-			} else {
-				w.WriteHeader(rsp.Code)
-			}
+			render.Render(w, r, resp)
 		}
 	})
 
@@ -990,12 +888,7 @@ func (siw *ServerInterfaceWrapper) GetSimpleNoExplodeArray(w http.ResponseWriter
 	var handler = http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		resp := siw.Handler.GetSimpleNoExplodeArray(w, r, param)
 		if resp != nil {
-			rsp := resp.Response()
-			if rsp.Body != nil {
-				render.Render(w, r, rsp)
-			} else {
-				w.WriteHeader(rsp.Code)
-			}
+			render.Render(w, r, resp)
 		}
 	})
 
@@ -1017,12 +910,7 @@ func (siw *ServerInterfaceWrapper) GetSimpleNoExplodeObject(w http.ResponseWrite
 	var handler = http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		resp := siw.Handler.GetSimpleNoExplodeObject(w, r, param)
 		if resp != nil {
-			rsp := resp.Response()
-			if rsp.Body != nil {
-				render.Render(w, r, rsp)
-			} else {
-				w.WriteHeader(rsp.Code)
-			}
+			render.Render(w, r, resp)
 		}
 	})
 
@@ -1044,12 +932,7 @@ func (siw *ServerInterfaceWrapper) GetSimplePrimitive(w http.ResponseWriter, r *
 	var handler = http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		resp := siw.Handler.GetSimplePrimitive(w, r, param)
 		if resp != nil {
-			rsp := resp.Response()
-			if rsp.Body != nil {
-				render.Render(w, r, rsp)
-			} else {
-				w.WriteHeader(rsp.Code)
-			}
+			render.Render(w, r, resp)
 		}
 	})
 
@@ -1068,12 +951,7 @@ func (siw *ServerInterfaceWrapper) GetStartingWithNumber(w http.ResponseWriter, 
 	var handler = http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		resp := siw.Handler.GetStartingWithNumber(w, r, n1param)
 		if resp != nil {
-			rsp := resp.Response()
-			if rsp.Body != nil {
-				render.Render(w, r, rsp)
-			} else {
-				w.WriteHeader(rsp.Code)
-			}
+			render.Render(w, r, resp)
 		}
 	})
 

--- a/internal/test/parameters/parameters_test.go
+++ b/internal/test/parameters/parameters_test.go
@@ -25,7 +25,7 @@ type testServer struct {
 	headerParams    *GetHeaderParams
 }
 
-func (t *testServer) reset() *Response {
+func (t *testServer) reset() Responser {
 	t.array = nil
 	t.object = nil
 	t.complexObject = nil
@@ -39,110 +39,110 @@ func (t *testServer) reset() *Response {
 	return nil
 }
 
-//  (GET /contentObject/{param})
-func (t *testServer) GetContentObject(w http.ResponseWriter, r *http.Request, param ComplexObject) *Response {
+// (GET /contentObject/{param})
+func (t *testServer) GetContentObject(w http.ResponseWriter, r *http.Request, param ComplexObject) Responser {
 	t.complexObject = &param
 	return nil
 }
 
-//  (GET /labelExplodeArray/{.param*})
-func (t *testServer) GetLabelExplodeArray(w http.ResponseWriter, r *http.Request, param []int32) *Response {
+// (GET /labelExplodeArray/{.param*})
+func (t *testServer) GetLabelExplodeArray(w http.ResponseWriter, r *http.Request, param []int32) Responser {
 	t.array = param
 	return nil
 }
 
-//  (GET /labelExplodeObject/{.param*})
-func (t *testServer) GetLabelExplodeObject(w http.ResponseWriter, r *http.Request, param Object) *Response {
+// (GET /labelExplodeObject/{.param*})
+func (t *testServer) GetLabelExplodeObject(w http.ResponseWriter, r *http.Request, param Object) Responser {
 	t.object = &param
 	return nil
 }
 
-//  (GET /labelNoExplodeArray/{.param})
-func (t *testServer) GetLabelNoExplodeArray(w http.ResponseWriter, r *http.Request, param []int32) *Response {
+// (GET /labelNoExplodeArray/{.param})
+func (t *testServer) GetLabelNoExplodeArray(w http.ResponseWriter, r *http.Request, param []int32) Responser {
 	t.array = param
 	return nil
 }
 
-//  (GET /labelNoExplodeObject/{.param})
-func (t *testServer) GetLabelNoExplodeObject(w http.ResponseWriter, r *http.Request, param Object) *Response {
+// (GET /labelNoExplodeObject/{.param})
+func (t *testServer) GetLabelNoExplodeObject(w http.ResponseWriter, r *http.Request, param Object) Responser {
 	t.object = &param
 	return nil
 }
 
-//  (GET /matrixExplodeArray/{.param*})
-func (t *testServer) GetMatrixExplodeArray(w http.ResponseWriter, r *http.Request, param []int32) *Response {
+// (GET /matrixExplodeArray/{.param*})
+func (t *testServer) GetMatrixExplodeArray(w http.ResponseWriter, r *http.Request, param []int32) Responser {
 	t.array = param
 	return nil
 }
 
-//  (GET /matrixExplodeObject/{.param*})
-func (t *testServer) GetMatrixExplodeObject(w http.ResponseWriter, r *http.Request, param Object) *Response {
+// (GET /matrixExplodeObject/{.param*})
+func (t *testServer) GetMatrixExplodeObject(w http.ResponseWriter, r *http.Request, param Object) Responser {
 	t.object = &param
 	return nil
 }
 
-//  (GET /matrixNoExplodeArray/{.param})
-func (t *testServer) GetMatrixNoExplodeArray(w http.ResponseWriter, r *http.Request, param []int32) *Response {
+// (GET /matrixNoExplodeArray/{.param})
+func (t *testServer) GetMatrixNoExplodeArray(w http.ResponseWriter, r *http.Request, param []int32) Responser {
 	t.array = param
 	return nil
 }
 
-//  (GET /matrixNoExplodeObject/{.param})
-func (t *testServer) GetMatrixNoExplodeObject(w http.ResponseWriter, r *http.Request, param Object) *Response {
+// (GET /matrixNoExplodeObject/{.param})
+func (t *testServer) GetMatrixNoExplodeObject(w http.ResponseWriter, r *http.Request, param Object) Responser {
 	t.object = &param
 	return nil
 }
 
-//  (GET /simpleExplodeArray/{param*})
-func (t *testServer) GetSimpleExplodeArray(w http.ResponseWriter, r *http.Request, param []int32) *Response {
+// (GET /simpleExplodeArray/{param*})
+func (t *testServer) GetSimpleExplodeArray(w http.ResponseWriter, r *http.Request, param []int32) Responser {
 	t.array = param
 	return nil
 }
 
-//  (GET /simpleExplodeObject/{param*})
-func (t *testServer) GetSimpleExplodeObject(w http.ResponseWriter, r *http.Request, param Object) *Response {
+// (GET /simpleExplodeObject/{param*})
+func (t *testServer) GetSimpleExplodeObject(w http.ResponseWriter, r *http.Request, param Object) Responser {
 	t.object = &param
 	return nil
 }
 
-//  (GET /simpleNoExplodeArray/{param})
-func (t *testServer) GetSimpleNoExplodeArray(w http.ResponseWriter, r *http.Request, param []int32) *Response {
+// (GET /simpleNoExplodeArray/{param})
+func (t *testServer) GetSimpleNoExplodeArray(w http.ResponseWriter, r *http.Request, param []int32) Responser {
 	t.array = param
 	return nil
 }
 
-//  (GET /simpleNoExplodeObject/{param})
-func (t *testServer) GetSimpleNoExplodeObject(w http.ResponseWriter, r *http.Request, param Object) *Response {
+// (GET /simpleNoExplodeObject/{param})
+func (t *testServer) GetSimpleNoExplodeObject(w http.ResponseWriter, r *http.Request, param Object) Responser {
 	t.object = &param
 	return nil
 }
 
-//  (GET /passThrough/{param})
-func (t *testServer) GetPassThrough(w http.ResponseWriter, r *http.Request, param string) *Response {
+// (GET /passThrough/{param})
+func (t *testServer) GetPassThrough(w http.ResponseWriter, r *http.Request, param string) Responser {
 	t.passThrough = &param
 	return nil
 }
 
-//  (GET /startingWithjNumber/{param})
-func (t *testServer) GetStartingWithNumber(w http.ResponseWriter, r *http.Request, n1param string) *Response {
+// (GET /startingWithjNumber/{param})
+func (t *testServer) GetStartingWithNumber(w http.ResponseWriter, r *http.Request, n1param string) Responser {
 	t.n1param = &n1param
 	return nil
 }
 
 // (GET /queryDeepObject)
-func (t *testServer) GetDeepObject(w http.ResponseWriter, r *http.Request, params GetDeepObjectParams) *Response {
+func (t *testServer) GetDeepObject(w http.ResponseWriter, r *http.Request, params GetDeepObjectParams) Responser {
 	t.complexObject = &params.DeepObj
 	return nil
 }
 
-//  (GET /simplePrimitive/{param})
-func (t *testServer) GetSimplePrimitive(w http.ResponseWriter, r *http.Request, param int32) *Response {
+// (GET /simplePrimitive/{param})
+func (t *testServer) GetSimplePrimitive(w http.ResponseWriter, r *http.Request, param int32) Responser {
 	t.primitive = &param
 	return nil
 }
 
-//  (GET /queryForm)
-func (t *testServer) GetQueryForm(w http.ResponseWriter, r *http.Request, params GetQueryFormParams) *Response {
+// (GET /queryForm)
+func (t *testServer) GetQueryForm(w http.ResponseWriter, r *http.Request, params GetQueryFormParams) Responser {
 	t.queryParams = &params
 	if params.Ea != nil {
 		t.array = params.Ea
@@ -174,8 +174,8 @@ func (t *testServer) GetQueryForm(w http.ResponseWriter, r *http.Request, params
 	return nil
 }
 
-//  (GET /header)
-func (t *testServer) GetHeader(w http.ResponseWriter, r *http.Request, params GetHeaderParams) *Response {
+// (GET /header)
+func (t *testServer) GetHeader(w http.ResponseWriter, r *http.Request, params GetHeaderParams) Responser {
 	t.headerParams = &params
 	if params.XPrimitive != nil {
 		t.primitive = params.XPrimitive
@@ -204,8 +204,8 @@ func (t *testServer) GetHeader(w http.ResponseWriter, r *http.Request, params Ge
 	return nil
 }
 
-//  (GET /cookie)
-func (t *testServer) GetCookie(w http.ResponseWriter, r *http.Request, params GetCookieParams) *Response {
+// (GET /cookie)
+func (t *testServer) GetCookie(w http.ResponseWriter, r *http.Request, params GetCookieParams) Responser {
 	t.cookieParams = &params
 	if params.Ea != nil {
 		t.array = params.Ea

--- a/internal/test/parameters/parameters_test.go
+++ b/internal/test/parameters/parameters_test.go
@@ -6,6 +6,7 @@ import (
 	"net/http"
 	"testing"
 
+	"github.com/go-chi/render"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 
@@ -25,7 +26,7 @@ type testServer struct {
 	headerParams    *GetHeaderParams
 }
 
-func (t *testServer) reset() Responser {
+func (t *testServer) reset() render.Renderer {
 	t.array = nil
 	t.object = nil
 	t.complexObject = nil
@@ -40,109 +41,109 @@ func (t *testServer) reset() Responser {
 }
 
 // (GET /contentObject/{param})
-func (t *testServer) GetContentObject(w http.ResponseWriter, r *http.Request, param ComplexObject) Responser {
+func (t *testServer) GetContentObject(w http.ResponseWriter, r *http.Request, param ComplexObject) render.Renderer {
 	t.complexObject = &param
 	return nil
 }
 
 // (GET /labelExplodeArray/{.param*})
-func (t *testServer) GetLabelExplodeArray(w http.ResponseWriter, r *http.Request, param []int32) Responser {
+func (t *testServer) GetLabelExplodeArray(w http.ResponseWriter, r *http.Request, param []int32) render.Renderer {
 	t.array = param
 	return nil
 }
 
 // (GET /labelExplodeObject/{.param*})
-func (t *testServer) GetLabelExplodeObject(w http.ResponseWriter, r *http.Request, param Object) Responser {
+func (t *testServer) GetLabelExplodeObject(w http.ResponseWriter, r *http.Request, param Object) render.Renderer {
 	t.object = &param
 	return nil
 }
 
 // (GET /labelNoExplodeArray/{.param})
-func (t *testServer) GetLabelNoExplodeArray(w http.ResponseWriter, r *http.Request, param []int32) Responser {
+func (t *testServer) GetLabelNoExplodeArray(w http.ResponseWriter, r *http.Request, param []int32) render.Renderer {
 	t.array = param
 	return nil
 }
 
 // (GET /labelNoExplodeObject/{.param})
-func (t *testServer) GetLabelNoExplodeObject(w http.ResponseWriter, r *http.Request, param Object) Responser {
+func (t *testServer) GetLabelNoExplodeObject(w http.ResponseWriter, r *http.Request, param Object) render.Renderer {
 	t.object = &param
 	return nil
 }
 
 // (GET /matrixExplodeArray/{.param*})
-func (t *testServer) GetMatrixExplodeArray(w http.ResponseWriter, r *http.Request, param []int32) Responser {
+func (t *testServer) GetMatrixExplodeArray(w http.ResponseWriter, r *http.Request, param []int32) render.Renderer {
 	t.array = param
 	return nil
 }
 
 // (GET /matrixExplodeObject/{.param*})
-func (t *testServer) GetMatrixExplodeObject(w http.ResponseWriter, r *http.Request, param Object) Responser {
+func (t *testServer) GetMatrixExplodeObject(w http.ResponseWriter, r *http.Request, param Object) render.Renderer {
 	t.object = &param
 	return nil
 }
 
 // (GET /matrixNoExplodeArray/{.param})
-func (t *testServer) GetMatrixNoExplodeArray(w http.ResponseWriter, r *http.Request, param []int32) Responser {
+func (t *testServer) GetMatrixNoExplodeArray(w http.ResponseWriter, r *http.Request, param []int32) render.Renderer {
 	t.array = param
 	return nil
 }
 
 // (GET /matrixNoExplodeObject/{.param})
-func (t *testServer) GetMatrixNoExplodeObject(w http.ResponseWriter, r *http.Request, param Object) Responser {
+func (t *testServer) GetMatrixNoExplodeObject(w http.ResponseWriter, r *http.Request, param Object) render.Renderer {
 	t.object = &param
 	return nil
 }
 
 // (GET /simpleExplodeArray/{param*})
-func (t *testServer) GetSimpleExplodeArray(w http.ResponseWriter, r *http.Request, param []int32) Responser {
+func (t *testServer) GetSimpleExplodeArray(w http.ResponseWriter, r *http.Request, param []int32) render.Renderer {
 	t.array = param
 	return nil
 }
 
 // (GET /simpleExplodeObject/{param*})
-func (t *testServer) GetSimpleExplodeObject(w http.ResponseWriter, r *http.Request, param Object) Responser {
+func (t *testServer) GetSimpleExplodeObject(w http.ResponseWriter, r *http.Request, param Object) render.Renderer {
 	t.object = &param
 	return nil
 }
 
 // (GET /simpleNoExplodeArray/{param})
-func (t *testServer) GetSimpleNoExplodeArray(w http.ResponseWriter, r *http.Request, param []int32) Responser {
+func (t *testServer) GetSimpleNoExplodeArray(w http.ResponseWriter, r *http.Request, param []int32) render.Renderer {
 	t.array = param
 	return nil
 }
 
 // (GET /simpleNoExplodeObject/{param})
-func (t *testServer) GetSimpleNoExplodeObject(w http.ResponseWriter, r *http.Request, param Object) Responser {
+func (t *testServer) GetSimpleNoExplodeObject(w http.ResponseWriter, r *http.Request, param Object) render.Renderer {
 	t.object = &param
 	return nil
 }
 
 // (GET /passThrough/{param})
-func (t *testServer) GetPassThrough(w http.ResponseWriter, r *http.Request, param string) Responser {
+func (t *testServer) GetPassThrough(w http.ResponseWriter, r *http.Request, param string) render.Renderer {
 	t.passThrough = &param
 	return nil
 }
 
 // (GET /startingWithjNumber/{param})
-func (t *testServer) GetStartingWithNumber(w http.ResponseWriter, r *http.Request, n1param string) Responser {
+func (t *testServer) GetStartingWithNumber(w http.ResponseWriter, r *http.Request, n1param string) render.Renderer {
 	t.n1param = &n1param
 	return nil
 }
 
 // (GET /queryDeepObject)
-func (t *testServer) GetDeepObject(w http.ResponseWriter, r *http.Request, params GetDeepObjectParams) Responser {
+func (t *testServer) GetDeepObject(w http.ResponseWriter, r *http.Request, params GetDeepObjectParams) render.Renderer {
 	t.complexObject = &params.DeepObj
 	return nil
 }
 
 // (GET /simplePrimitive/{param})
-func (t *testServer) GetSimplePrimitive(w http.ResponseWriter, r *http.Request, param int32) Responser {
+func (t *testServer) GetSimplePrimitive(w http.ResponseWriter, r *http.Request, param int32) render.Renderer {
 	t.primitive = &param
 	return nil
 }
 
 // (GET /queryForm)
-func (t *testServer) GetQueryForm(w http.ResponseWriter, r *http.Request, params GetQueryFormParams) Responser {
+func (t *testServer) GetQueryForm(w http.ResponseWriter, r *http.Request, params GetQueryFormParams) render.Renderer {
 	t.queryParams = &params
 	if params.Ea != nil {
 		t.array = params.Ea
@@ -175,7 +176,7 @@ func (t *testServer) GetQueryForm(w http.ResponseWriter, r *http.Request, params
 }
 
 // (GET /header)
-func (t *testServer) GetHeader(w http.ResponseWriter, r *http.Request, params GetHeaderParams) Responser {
+func (t *testServer) GetHeader(w http.ResponseWriter, r *http.Request, params GetHeaderParams) render.Renderer {
 	t.headerParams = &params
 	if params.XPrimitive != nil {
 		t.primitive = params.XPrimitive
@@ -205,7 +206,7 @@ func (t *testServer) GetHeader(w http.ResponseWriter, r *http.Request, params Ge
 }
 
 // (GET /cookie)
-func (t *testServer) GetCookie(w http.ResponseWriter, r *http.Request, params GetCookieParams) Responser {
+func (t *testServer) GetCookie(w http.ResponseWriter, r *http.Request, params GetCookieParams) render.Renderer {
 	t.cookieParams = &params
 	if params.Ea != nil {
 		t.array = params.Ea

--- a/internal/test/schemas/schemas.gen.go
+++ b/internal/test/schemas/schemas.gen.go
@@ -141,11 +141,6 @@ func (Issue185JSONRequestBody) Bind(*http.Request) error {
 // Issue9JSONRequestBody defines body for Issue9 for application/json ContentType.
 type Issue9JSONRequestBody Issue9JSONBody
 
-// Responser is an interface for responding to a request.
-type Responser interface {
-	Response() *Response
-}
-
 // Response is a common response struct for all the API calls.
 // A Response object may be instantiated via functions for specific operation responses.
 // It may also be instantiated directly, for the purpose of responding with a single status code.
@@ -155,29 +150,12 @@ type Response struct {
 	ContentType string
 }
 
-// Response implements the Responser interface.
-func (r *Response) Response() *Response {
-	return r
-}
-
 // Render implements the render.Renderer interface. It sets the Content-Type header
 // and status code based on the response definition.
 func (resp *Response) Render(w http.ResponseWriter, r *http.Request) error {
 	w.Header().Set("Content-Type", resp.ContentType)
 	render.Status(r, resp.Code)
 	return nil
-}
-
-// Status is a builder method to override the default status code for a response.
-func (resp *Response) Status(code int) *Response {
-	resp.Code = code
-	return resp
-}
-
-// ContentType is a builder method to override the default content type for a response.
-func (resp *Response) ContentTyp(contentType string) *Response {
-	resp.ContentType = contentType
-	return resp
 }
 
 // MarshalJSON implements the json.Marshaler interface.
@@ -284,34 +262,34 @@ func PostPr66JSON200Response(body CustomGoTypeWithAlias) *Response {
 type ServerInterface interface {
 
 	// (GET /ensure-everything-is-referenced)
-	EnsureEverythingIsReferenced(w http.ResponseWriter, r *http.Request) Responser
+	EnsureEverythingIsReferenced(w http.ResponseWriter, r *http.Request) render.Renderer
 
 	// (GET /issues/127)
-	Issue127(w http.ResponseWriter, r *http.Request) Responser
+	Issue127(w http.ResponseWriter, r *http.Request) render.Renderer
 
 	// (GET /issues/185)
-	Issue185(w http.ResponseWriter, r *http.Request) Responser
+	Issue185(w http.ResponseWriter, r *http.Request) render.Renderer
 
 	// (GET /issues/209/${str})
-	Issue209(w http.ResponseWriter, r *http.Request, str StringInPath) Responser
+	Issue209(w http.ResponseWriter, r *http.Request, str StringInPath) render.Renderer
 
 	// (GET /issues/30/{fallthrough})
-	Issue30(w http.ResponseWriter, r *http.Request, pFallthrough string) Responser
+	Issue30(w http.ResponseWriter, r *http.Request, pFallthrough string) render.Renderer
 
 	// (GET /issues/375)
-	GetIssues375(w http.ResponseWriter, r *http.Request) Responser
+	GetIssues375(w http.ResponseWriter, r *http.Request) render.Renderer
 
 	// (GET /issues/41/{1param})
-	Issue41(w http.ResponseWriter, r *http.Request, n1param N5startsWithNumber) Responser
+	Issue41(w http.ResponseWriter, r *http.Request, n1param N5startsWithNumber) render.Renderer
 
 	// (GET /issues/9)
-	Issue9(w http.ResponseWriter, r *http.Request, params Issue9Params) Responser
+	Issue9(w http.ResponseWriter, r *http.Request, params Issue9Params) render.Renderer
 
 	// (GET /pr/66)
-	GetPr66(w http.ResponseWriter, r *http.Request, params GetPr66Params) Responser
+	GetPr66(w http.ResponseWriter, r *http.Request, params GetPr66Params) render.Renderer
 
 	// (POST /pr/66)
-	PostPr66(w http.ResponseWriter, r *http.Request, params PostPr66Params) Responser
+	PostPr66(w http.ResponseWriter, r *http.Request, params PostPr66Params) render.Renderer
 }
 
 // ServerInterfaceWrapper converts contexts to parameters.
@@ -330,12 +308,7 @@ func (siw *ServerInterfaceWrapper) EnsureEverythingIsReferenced(w http.ResponseW
 	var handler = http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		resp := siw.Handler.EnsureEverythingIsReferenced(w, r)
 		if resp != nil {
-			rsp := resp.Response()
-			if rsp.Body != nil {
-				render.Render(w, r, rsp)
-			} else {
-				w.WriteHeader(rsp.Code)
-			}
+			render.Render(w, r, resp)
 		}
 	})
 
@@ -351,12 +324,7 @@ func (siw *ServerInterfaceWrapper) Issue127(w http.ResponseWriter, r *http.Reque
 	var handler = http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		resp := siw.Handler.Issue127(w, r)
 		if resp != nil {
-			rsp := resp.Response()
-			if rsp.Body != nil {
-				render.Render(w, r, rsp)
-			} else {
-				w.WriteHeader(rsp.Code)
-			}
+			render.Render(w, r, resp)
 		}
 	})
 
@@ -372,12 +340,7 @@ func (siw *ServerInterfaceWrapper) Issue185(w http.ResponseWriter, r *http.Reque
 	var handler = http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		resp := siw.Handler.Issue185(w, r)
 		if resp != nil {
-			rsp := resp.Response()
-			if rsp.Body != nil {
-				render.Render(w, r, rsp)
-			} else {
-				w.WriteHeader(rsp.Code)
-			}
+			render.Render(w, r, resp)
 		}
 	})
 
@@ -401,12 +364,7 @@ func (siw *ServerInterfaceWrapper) Issue209(w http.ResponseWriter, r *http.Reque
 	var handler = http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		resp := siw.Handler.Issue209(w, r, str)
 		if resp != nil {
-			rsp := resp.Response()
-			if rsp.Body != nil {
-				render.Render(w, r, rsp)
-			} else {
-				w.WriteHeader(rsp.Code)
-			}
+			render.Render(w, r, resp)
 		}
 	})
 
@@ -430,12 +388,7 @@ func (siw *ServerInterfaceWrapper) Issue30(w http.ResponseWriter, r *http.Reques
 	var handler = http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		resp := siw.Handler.Issue30(w, r, pFallthrough)
 		if resp != nil {
-			rsp := resp.Response()
-			if rsp.Body != nil {
-				render.Render(w, r, rsp)
-			} else {
-				w.WriteHeader(rsp.Code)
-			}
+			render.Render(w, r, resp)
 		}
 	})
 
@@ -451,12 +404,7 @@ func (siw *ServerInterfaceWrapper) GetIssues375(w http.ResponseWriter, r *http.R
 	var handler = http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		resp := siw.Handler.GetIssues375(w, r)
 		if resp != nil {
-			rsp := resp.Response()
-			if rsp.Body != nil {
-				render.Render(w, r, rsp)
-			} else {
-				w.WriteHeader(rsp.Code)
-			}
+			render.Render(w, r, resp)
 		}
 	})
 
@@ -480,12 +428,7 @@ func (siw *ServerInterfaceWrapper) Issue41(w http.ResponseWriter, r *http.Reques
 	var handler = http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		resp := siw.Handler.Issue41(w, r, n1param)
 		if resp != nil {
-			rsp := resp.Response()
-			if rsp.Body != nil {
-				render.Render(w, r, rsp)
-			} else {
-				w.WriteHeader(rsp.Code)
-			}
+			render.Render(w, r, resp)
 		}
 	})
 
@@ -512,12 +455,7 @@ func (siw *ServerInterfaceWrapper) Issue9(w http.ResponseWriter, r *http.Request
 	var handler = http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		resp := siw.Handler.Issue9(w, r, params)
 		if resp != nil {
-			rsp := resp.Response()
-			if rsp.Body != nil {
-				render.Render(w, r, rsp)
-			} else {
-				w.WriteHeader(rsp.Code)
-			}
+			render.Render(w, r, resp)
 		}
 	})
 
@@ -544,12 +482,7 @@ func (siw *ServerInterfaceWrapper) GetPr66(w http.ResponseWriter, r *http.Reques
 	var handler = http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		resp := siw.Handler.GetPr66(w, r, params)
 		if resp != nil {
-			rsp := resp.Response()
-			if rsp.Body != nil {
-				render.Render(w, r, rsp)
-			} else {
-				w.WriteHeader(rsp.Code)
-			}
+			render.Render(w, r, resp)
 		}
 	})
 
@@ -576,12 +509,7 @@ func (siw *ServerInterfaceWrapper) PostPr66(w http.ResponseWriter, r *http.Reque
 	var handler = http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		resp := siw.Handler.PostPr66(w, r, params)
 		if resp != nil {
-			rsp := resp.Response()
-			if rsp.Body != nil {
-				render.Render(w, r, rsp)
-			} else {
-				w.WriteHeader(rsp.Code)
-			}
+			render.Render(w, r, resp)
 		}
 	})
 

--- a/internal/test/schemas/schemas.gen.go
+++ b/internal/test/schemas/schemas.gen.go
@@ -141,19 +141,29 @@ func (Issue185JSONRequestBody) Bind(*http.Request) error {
 // Issue9JSONRequestBody defines body for Issue9 for application/json ContentType.
 type Issue9JSONRequestBody Issue9JSONBody
 
+// Responser is an interface for responding to a request.
+type Responser interface {
+	Response() *Response
+}
+
 // Response is a common response struct for all the API calls.
 // A Response object may be instantiated via functions for specific operation responses.
 // It may also be instantiated directly, for the purpose of responding with a single status code.
 type Response struct {
-	body        interface{}
+	Body        interface{}
 	Code        int
-	contentType string
+	ContentType string
+}
+
+// Response implements the Responser interface.
+func (r *Response) Response() *Response {
+	return r
 }
 
 // Render implements the render.Renderer interface. It sets the Content-Type header
 // and status code based on the response definition.
 func (resp *Response) Render(w http.ResponseWriter, r *http.Request) error {
-	w.Header().Set("Content-Type", resp.contentType)
+	w.Header().Set("Content-Type", resp.ContentType)
 	render.Status(r, resp.Code)
 	return nil
 }
@@ -165,21 +175,21 @@ func (resp *Response) Status(code int) *Response {
 }
 
 // ContentType is a builder method to override the default content type for a response.
-func (resp *Response) ContentType(contentType string) *Response {
-	resp.contentType = contentType
+func (resp *Response) ContentTyp(contentType string) *Response {
+	resp.ContentType = contentType
 	return resp
 }
 
 // MarshalJSON implements the json.Marshaler interface.
 // This is used to only marshal the body of the response.
 func (resp *Response) MarshalJSON() ([]byte, error) {
-	return json.Marshal(resp.body)
+	return json.Marshal(resp.Body)
 }
 
 // MarshalXML implements the xml.Marshaler interface.
 // This is used to only marshal the body of the response.
 func (resp *Response) MarshalXML(e *xml.Encoder, start xml.StartElement) error {
-	return e.Encode(resp.body)
+	return e.Encode(resp.Body)
 }
 
 // EnsureEverythingIsReferencedJSON200Response is a constructor method for a EnsureEverythingIsReferenced response.
@@ -194,9 +204,9 @@ func EnsureEverythingIsReferencedJSON200Response(body struct {
 	CustomStringType *CustomStringType `foo:"bar" json:"customStringType,omitempty"`
 }) *Response {
 	return &Response{
-		body:        body,
+		Body:        body,
 		Code:        200,
-		contentType: "application/json",
+		ContentType: "application/json",
 	}
 }
 
@@ -204,9 +214,9 @@ func EnsureEverythingIsReferencedJSON200Response(body struct {
 // A *Response is returned with the configured status code and content type from the spec.
 func Issue127JSON200Response(body GenericObject) *Response {
 	return &Response{
-		body:        body,
+		Body:        body,
 		Code:        200,
-		contentType: "application/json",
+		ContentType: "application/json",
 	}
 }
 
@@ -214,9 +224,9 @@ func Issue127JSON200Response(body GenericObject) *Response {
 // A *Response is returned with the configured status code and content type from the spec.
 func Issue127XML200Response(body GenericObject) *Response {
 	return &Response{
-		body:        body,
+		Body:        body,
 		Code:        200,
-		contentType: "application/xml",
+		ContentType: "application/xml",
 	}
 }
 
@@ -224,9 +234,9 @@ func Issue127XML200Response(body GenericObject) *Response {
 // A *Response is returned with the configured status code and content type from the spec.
 func Issue127YAML200Response(body GenericObject) *Response {
 	return &Response{
-		body:        body,
+		Body:        body,
 		Code:        200,
-		contentType: "text/yaml",
+		ContentType: "text/yaml",
 	}
 }
 
@@ -234,9 +244,9 @@ func Issue127YAML200Response(body GenericObject) *Response {
 // A *Response is returned with the configured status code and content type from the spec.
 func Issue127JSONDefaultResponse(body GenericObject) *Response {
 	return &Response{
-		body:        body,
+		Body:        body,
 		Code:        200,
-		contentType: "application/json",
+		ContentType: "application/json",
 	}
 }
 
@@ -244,9 +254,9 @@ func Issue127JSONDefaultResponse(body GenericObject) *Response {
 // A *Response is returned with the configured status code and content type from the spec.
 func GetIssues375JSON200Response(body EnumInObjInArray) *Response {
 	return &Response{
-		body:        body,
+		Body:        body,
 		Code:        200,
-		contentType: "application/json",
+		ContentType: "application/json",
 	}
 }
 
@@ -254,9 +264,9 @@ func GetIssues375JSON200Response(body EnumInObjInArray) *Response {
 // A *Response is returned with the configured status code and content type from the spec.
 func GetPr66JSON200Response(body CustomGoType) *Response {
 	return &Response{
-		body:        body,
+		Body:        body,
 		Code:        200,
-		contentType: "application/json",
+		ContentType: "application/json",
 	}
 }
 
@@ -264,9 +274,9 @@ func GetPr66JSON200Response(body CustomGoType) *Response {
 // A *Response is returned with the configured status code and content type from the spec.
 func PostPr66JSON200Response(body CustomGoTypeWithAlias) *Response {
 	return &Response{
-		body:        body,
+		Body:        body,
 		Code:        200,
-		contentType: "application/json",
+		ContentType: "application/json",
 	}
 }
 
@@ -274,34 +284,34 @@ func PostPr66JSON200Response(body CustomGoTypeWithAlias) *Response {
 type ServerInterface interface {
 
 	// (GET /ensure-everything-is-referenced)
-	EnsureEverythingIsReferenced(w http.ResponseWriter, r *http.Request) *Response
+	EnsureEverythingIsReferenced(w http.ResponseWriter, r *http.Request) Responser
 
 	// (GET /issues/127)
-	Issue127(w http.ResponseWriter, r *http.Request) *Response
+	Issue127(w http.ResponseWriter, r *http.Request) Responser
 
 	// (GET /issues/185)
-	Issue185(w http.ResponseWriter, r *http.Request) *Response
+	Issue185(w http.ResponseWriter, r *http.Request) Responser
 
 	// (GET /issues/209/${str})
-	Issue209(w http.ResponseWriter, r *http.Request, str StringInPath) *Response
+	Issue209(w http.ResponseWriter, r *http.Request, str StringInPath) Responser
 
 	// (GET /issues/30/{fallthrough})
-	Issue30(w http.ResponseWriter, r *http.Request, pFallthrough string) *Response
+	Issue30(w http.ResponseWriter, r *http.Request, pFallthrough string) Responser
 
 	// (GET /issues/375)
-	GetIssues375(w http.ResponseWriter, r *http.Request) *Response
+	GetIssues375(w http.ResponseWriter, r *http.Request) Responser
 
 	// (GET /issues/41/{1param})
-	Issue41(w http.ResponseWriter, r *http.Request, n1param N5startsWithNumber) *Response
+	Issue41(w http.ResponseWriter, r *http.Request, n1param N5startsWithNumber) Responser
 
 	// (GET /issues/9)
-	Issue9(w http.ResponseWriter, r *http.Request, params Issue9Params) *Response
+	Issue9(w http.ResponseWriter, r *http.Request, params Issue9Params) Responser
 
 	// (GET /pr/66)
-	GetPr66(w http.ResponseWriter, r *http.Request, params GetPr66Params) *Response
+	GetPr66(w http.ResponseWriter, r *http.Request, params GetPr66Params) Responser
 
 	// (POST /pr/66)
-	PostPr66(w http.ResponseWriter, r *http.Request, params PostPr66Params) *Response
+	PostPr66(w http.ResponseWriter, r *http.Request, params PostPr66Params) Responser
 }
 
 // ServerInterfaceWrapper converts contexts to parameters.
@@ -320,10 +330,11 @@ func (siw *ServerInterfaceWrapper) EnsureEverythingIsReferenced(w http.ResponseW
 	var handler = http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		resp := siw.Handler.EnsureEverythingIsReferenced(w, r)
 		if resp != nil {
-			if resp.body != nil {
-				render.Render(w, r, resp)
+			rsp := resp.Response()
+			if rsp.Body != nil {
+				render.Render(w, r, rsp)
 			} else {
-				w.WriteHeader(resp.Code)
+				w.WriteHeader(rsp.Code)
 			}
 		}
 	})
@@ -340,10 +351,11 @@ func (siw *ServerInterfaceWrapper) Issue127(w http.ResponseWriter, r *http.Reque
 	var handler = http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		resp := siw.Handler.Issue127(w, r)
 		if resp != nil {
-			if resp.body != nil {
-				render.Render(w, r, resp)
+			rsp := resp.Response()
+			if rsp.Body != nil {
+				render.Render(w, r, rsp)
 			} else {
-				w.WriteHeader(resp.Code)
+				w.WriteHeader(rsp.Code)
 			}
 		}
 	})
@@ -360,10 +372,11 @@ func (siw *ServerInterfaceWrapper) Issue185(w http.ResponseWriter, r *http.Reque
 	var handler = http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		resp := siw.Handler.Issue185(w, r)
 		if resp != nil {
-			if resp.body != nil {
-				render.Render(w, r, resp)
+			rsp := resp.Response()
+			if rsp.Body != nil {
+				render.Render(w, r, rsp)
 			} else {
-				w.WriteHeader(resp.Code)
+				w.WriteHeader(rsp.Code)
 			}
 		}
 	})
@@ -388,10 +401,11 @@ func (siw *ServerInterfaceWrapper) Issue209(w http.ResponseWriter, r *http.Reque
 	var handler = http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		resp := siw.Handler.Issue209(w, r, str)
 		if resp != nil {
-			if resp.body != nil {
-				render.Render(w, r, resp)
+			rsp := resp.Response()
+			if rsp.Body != nil {
+				render.Render(w, r, rsp)
 			} else {
-				w.WriteHeader(resp.Code)
+				w.WriteHeader(rsp.Code)
 			}
 		}
 	})
@@ -416,10 +430,11 @@ func (siw *ServerInterfaceWrapper) Issue30(w http.ResponseWriter, r *http.Reques
 	var handler = http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		resp := siw.Handler.Issue30(w, r, pFallthrough)
 		if resp != nil {
-			if resp.body != nil {
-				render.Render(w, r, resp)
+			rsp := resp.Response()
+			if rsp.Body != nil {
+				render.Render(w, r, rsp)
 			} else {
-				w.WriteHeader(resp.Code)
+				w.WriteHeader(rsp.Code)
 			}
 		}
 	})
@@ -436,10 +451,11 @@ func (siw *ServerInterfaceWrapper) GetIssues375(w http.ResponseWriter, r *http.R
 	var handler = http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		resp := siw.Handler.GetIssues375(w, r)
 		if resp != nil {
-			if resp.body != nil {
-				render.Render(w, r, resp)
+			rsp := resp.Response()
+			if rsp.Body != nil {
+				render.Render(w, r, rsp)
 			} else {
-				w.WriteHeader(resp.Code)
+				w.WriteHeader(rsp.Code)
 			}
 		}
 	})
@@ -464,10 +480,11 @@ func (siw *ServerInterfaceWrapper) Issue41(w http.ResponseWriter, r *http.Reques
 	var handler = http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		resp := siw.Handler.Issue41(w, r, n1param)
 		if resp != nil {
-			if resp.body != nil {
-				render.Render(w, r, resp)
+			rsp := resp.Response()
+			if rsp.Body != nil {
+				render.Render(w, r, rsp)
 			} else {
-				w.WriteHeader(resp.Code)
+				w.WriteHeader(rsp.Code)
 			}
 		}
 	})
@@ -495,10 +512,11 @@ func (siw *ServerInterfaceWrapper) Issue9(w http.ResponseWriter, r *http.Request
 	var handler = http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		resp := siw.Handler.Issue9(w, r, params)
 		if resp != nil {
-			if resp.body != nil {
-				render.Render(w, r, resp)
+			rsp := resp.Response()
+			if rsp.Body != nil {
+				render.Render(w, r, rsp)
 			} else {
-				w.WriteHeader(resp.Code)
+				w.WriteHeader(rsp.Code)
 			}
 		}
 	})
@@ -526,10 +544,11 @@ func (siw *ServerInterfaceWrapper) GetPr66(w http.ResponseWriter, r *http.Reques
 	var handler = http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		resp := siw.Handler.GetPr66(w, r, params)
 		if resp != nil {
-			if resp.body != nil {
-				render.Render(w, r, resp)
+			rsp := resp.Response()
+			if rsp.Body != nil {
+				render.Render(w, r, rsp)
 			} else {
-				w.WriteHeader(resp.Code)
+				w.WriteHeader(rsp.Code)
 			}
 		}
 	})
@@ -557,10 +576,11 @@ func (siw *ServerInterfaceWrapper) PostPr66(w http.ResponseWriter, r *http.Reque
 	var handler = http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		resp := siw.Handler.PostPr66(w, r, params)
 		if resp != nil {
-			if resp.body != nil {
-				render.Render(w, r, resp)
+			rsp := resp.Response()
+			if rsp.Body != nil {
+				render.Render(w, r, rsp)
 			} else {
-				w.WriteHeader(resp.Code)
+				w.WriteHeader(rsp.Code)
 			}
 		}
 	})

--- a/internal/test/schemas/schemas.gen.go
+++ b/internal/test/schemas/schemas.gen.go
@@ -152,7 +152,7 @@ type Response struct {
 
 // Render implements the render.Renderer interface. It sets the Content-Type header
 // and status code based on the response definition.
-func (resp *Response) Render(w http.ResponseWriter, r *http.Request) error {
+func (resp Response) Render(w http.ResponseWriter, r *http.Request) error {
 	w.Header().Set("Content-Type", resp.ContentType)
 	render.Status(r, resp.Code)
 	return nil
@@ -160,18 +160,18 @@ func (resp *Response) Render(w http.ResponseWriter, r *http.Request) error {
 
 // MarshalJSON implements the json.Marshaler interface.
 // This is used to only marshal the body of the response.
-func (resp *Response) MarshalJSON() ([]byte, error) {
+func (resp Response) MarshalJSON() ([]byte, error) {
 	return json.Marshal(resp.Body)
 }
 
 // MarshalXML implements the xml.Marshaler interface.
 // This is used to only marshal the body of the response.
-func (resp *Response) MarshalXML(e *xml.Encoder, start xml.StartElement) error {
+func (resp Response) MarshalXML(e *xml.Encoder, start xml.StartElement) error {
 	return e.Encode(resp.Body)
 }
 
 // EnsureEverythingIsReferencedJSON200Response is a constructor method for a EnsureEverythingIsReferenced response.
-// A *Response is returned with the configured status code and content type from the spec.
+// A Response is returned with the configured status code and content type from the spec.
 func EnsureEverythingIsReferencedJSON200Response(body struct {
 	AnyType1 *AnyType1 `json:"anyType1,omitempty"`
 
@@ -180,8 +180,8 @@ func EnsureEverythingIsReferencedJSON200Response(body struct {
 	// This should be an interface{}
 	AnyType2         *AnyType2         `json:"anyType2,omitempty"`
 	CustomStringType *CustomStringType `foo:"bar" json:"customStringType,omitempty"`
-}) *Response {
-	return &Response{
+}) Response {
+	return Response{
 		Body:        body,
 		Code:        200,
 		ContentType: "application/json",
@@ -189,9 +189,9 @@ func EnsureEverythingIsReferencedJSON200Response(body struct {
 }
 
 // Issue127JSON200Response is a constructor method for a Issue127 response.
-// A *Response is returned with the configured status code and content type from the spec.
-func Issue127JSON200Response(body GenericObject) *Response {
-	return &Response{
+// A Response is returned with the configured status code and content type from the spec.
+func Issue127JSON200Response(body GenericObject) Response {
+	return Response{
 		Body:        body,
 		Code:        200,
 		ContentType: "application/json",
@@ -199,9 +199,9 @@ func Issue127JSON200Response(body GenericObject) *Response {
 }
 
 // Issue127XML200Response is a constructor method for a Issue127 response.
-// A *Response is returned with the configured status code and content type from the spec.
-func Issue127XML200Response(body GenericObject) *Response {
-	return &Response{
+// A Response is returned with the configured status code and content type from the spec.
+func Issue127XML200Response(body GenericObject) Response {
+	return Response{
 		Body:        body,
 		Code:        200,
 		ContentType: "application/xml",
@@ -209,9 +209,9 @@ func Issue127XML200Response(body GenericObject) *Response {
 }
 
 // Issue127YAML200Response is a constructor method for a Issue127 response.
-// A *Response is returned with the configured status code and content type from the spec.
-func Issue127YAML200Response(body GenericObject) *Response {
-	return &Response{
+// A Response is returned with the configured status code and content type from the spec.
+func Issue127YAML200Response(body GenericObject) Response {
+	return Response{
 		Body:        body,
 		Code:        200,
 		ContentType: "text/yaml",
@@ -219,9 +219,9 @@ func Issue127YAML200Response(body GenericObject) *Response {
 }
 
 // Issue127JSONDefaultResponse is a constructor method for a Issue127 response.
-// A *Response is returned with the configured status code and content type from the spec.
-func Issue127JSONDefaultResponse(body GenericObject) *Response {
-	return &Response{
+// A Response is returned with the configured status code and content type from the spec.
+func Issue127JSONDefaultResponse(body GenericObject) Response {
+	return Response{
 		Body:        body,
 		Code:        200,
 		ContentType: "application/json",
@@ -229,9 +229,9 @@ func Issue127JSONDefaultResponse(body GenericObject) *Response {
 }
 
 // GetIssues375JSON200Response is a constructor method for a GetIssues375 response.
-// A *Response is returned with the configured status code and content type from the spec.
-func GetIssues375JSON200Response(body EnumInObjInArray) *Response {
-	return &Response{
+// A Response is returned with the configured status code and content type from the spec.
+func GetIssues375JSON200Response(body EnumInObjInArray) Response {
+	return Response{
 		Body:        body,
 		Code:        200,
 		ContentType: "application/json",
@@ -239,9 +239,9 @@ func GetIssues375JSON200Response(body EnumInObjInArray) *Response {
 }
 
 // GetPr66JSON200Response is a constructor method for a GetPr66 response.
-// A *Response is returned with the configured status code and content type from the spec.
-func GetPr66JSON200Response(body CustomGoType) *Response {
-	return &Response{
+// A Response is returned with the configured status code and content type from the spec.
+func GetPr66JSON200Response(body CustomGoType) Response {
+	return Response{
 		Body:        body,
 		Code:        200,
 		ContentType: "application/json",
@@ -249,9 +249,9 @@ func GetPr66JSON200Response(body CustomGoType) *Response {
 }
 
 // PostPr66JSON200Response is a constructor method for a PostPr66 response.
-// A *Response is returned with the configured status code and content type from the spec.
-func PostPr66JSON200Response(body CustomGoTypeWithAlias) *Response {
-	return &Response{
+// A Response is returned with the configured status code and content type from the spec.
+func PostPr66JSON200Response(body CustomGoTypeWithAlias) Response {
+	return Response{
 		Body:        body,
 		Code:        200,
 		ContentType: "application/json",
@@ -308,6 +308,11 @@ func (siw *ServerInterfaceWrapper) EnsureEverythingIsReferenced(w http.ResponseW
 	var handler = http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		resp := siw.Handler.EnsureEverythingIsReferenced(w, r)
 		if resp != nil {
+			if resp, ok := resp.(Response); ok && resp.Body == nil {
+				w.WriteHeader(resp.Code)
+				return
+			}
+
 			render.Render(w, r, resp)
 		}
 	})
@@ -324,6 +329,11 @@ func (siw *ServerInterfaceWrapper) Issue127(w http.ResponseWriter, r *http.Reque
 	var handler = http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		resp := siw.Handler.Issue127(w, r)
 		if resp != nil {
+			if resp, ok := resp.(Response); ok && resp.Body == nil {
+				w.WriteHeader(resp.Code)
+				return
+			}
+
 			render.Render(w, r, resp)
 		}
 	})
@@ -340,6 +350,11 @@ func (siw *ServerInterfaceWrapper) Issue185(w http.ResponseWriter, r *http.Reque
 	var handler = http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		resp := siw.Handler.Issue185(w, r)
 		if resp != nil {
+			if resp, ok := resp.(Response); ok && resp.Body == nil {
+				w.WriteHeader(resp.Code)
+				return
+			}
+
 			render.Render(w, r, resp)
 		}
 	})
@@ -364,6 +379,11 @@ func (siw *ServerInterfaceWrapper) Issue209(w http.ResponseWriter, r *http.Reque
 	var handler = http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		resp := siw.Handler.Issue209(w, r, str)
 		if resp != nil {
+			if resp, ok := resp.(Response); ok && resp.Body == nil {
+				w.WriteHeader(resp.Code)
+				return
+			}
+
 			render.Render(w, r, resp)
 		}
 	})
@@ -388,6 +408,11 @@ func (siw *ServerInterfaceWrapper) Issue30(w http.ResponseWriter, r *http.Reques
 	var handler = http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		resp := siw.Handler.Issue30(w, r, pFallthrough)
 		if resp != nil {
+			if resp, ok := resp.(Response); ok && resp.Body == nil {
+				w.WriteHeader(resp.Code)
+				return
+			}
+
 			render.Render(w, r, resp)
 		}
 	})
@@ -404,6 +429,11 @@ func (siw *ServerInterfaceWrapper) GetIssues375(w http.ResponseWriter, r *http.R
 	var handler = http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		resp := siw.Handler.GetIssues375(w, r)
 		if resp != nil {
+			if resp, ok := resp.(Response); ok && resp.Body == nil {
+				w.WriteHeader(resp.Code)
+				return
+			}
+
 			render.Render(w, r, resp)
 		}
 	})
@@ -428,6 +458,11 @@ func (siw *ServerInterfaceWrapper) Issue41(w http.ResponseWriter, r *http.Reques
 	var handler = http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		resp := siw.Handler.Issue41(w, r, n1param)
 		if resp != nil {
+			if resp, ok := resp.(Response); ok && resp.Body == nil {
+				w.WriteHeader(resp.Code)
+				return
+			}
+
 			render.Render(w, r, resp)
 		}
 	})
@@ -455,6 +490,11 @@ func (siw *ServerInterfaceWrapper) Issue9(w http.ResponseWriter, r *http.Request
 	var handler = http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		resp := siw.Handler.Issue9(w, r, params)
 		if resp != nil {
+			if resp, ok := resp.(Response); ok && resp.Body == nil {
+				w.WriteHeader(resp.Code)
+				return
+			}
+
 			render.Render(w, r, resp)
 		}
 	})
@@ -482,6 +522,11 @@ func (siw *ServerInterfaceWrapper) GetPr66(w http.ResponseWriter, r *http.Reques
 	var handler = http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		resp := siw.Handler.GetPr66(w, r, params)
 		if resp != nil {
+			if resp, ok := resp.(Response); ok && resp.Body == nil {
+				w.WriteHeader(resp.Code)
+				return
+			}
+
 			render.Render(w, r, resp)
 		}
 	})
@@ -509,6 +554,11 @@ func (siw *ServerInterfaceWrapper) PostPr66(w http.ResponseWriter, r *http.Reque
 	var handler = http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		resp := siw.Handler.PostPr66(w, r, params)
 		if resp != nil {
+			if resp, ok := resp.(Response); ok && resp.Body == nil {
+				w.WriteHeader(resp.Code)
+				return
+			}
+
 			render.Render(w, r, resp)
 		}
 	})

--- a/internal/test/server/server.gen.go
+++ b/internal/test/server/server.gen.go
@@ -156,7 +156,7 @@ type Response struct {
 
 // Render implements the render.Renderer interface. It sets the Content-Type header
 // and status code based on the response definition.
-func (resp *Response) Render(w http.ResponseWriter, r *http.Request) error {
+func (resp Response) Render(w http.ResponseWriter, r *http.Request) error {
 	w.Header().Set("Content-Type", resp.ContentType)
 	render.Status(r, resp.Code)
 	return nil
@@ -164,20 +164,20 @@ func (resp *Response) Render(w http.ResponseWriter, r *http.Request) error {
 
 // MarshalJSON implements the json.Marshaler interface.
 // This is used to only marshal the body of the response.
-func (resp *Response) MarshalJSON() ([]byte, error) {
+func (resp Response) MarshalJSON() ([]byte, error) {
 	return json.Marshal(resp.Body)
 }
 
 // MarshalXML implements the xml.Marshaler interface.
 // This is used to only marshal the body of the response.
-func (resp *Response) MarshalXML(e *xml.Encoder, start xml.StartElement) error {
+func (resp Response) MarshalXML(e *xml.Encoder, start xml.StartElement) error {
 	return e.Encode(resp.Body)
 }
 
 // GetEveryTypeOptionalJSON200Response is a constructor method for a GetEveryTypeOptional response.
-// A *Response is returned with the configured status code and content type from the spec.
-func GetEveryTypeOptionalJSON200Response(body EveryTypeOptional) *Response {
-	return &Response{
+// A Response is returned with the configured status code and content type from the spec.
+func GetEveryTypeOptionalJSON200Response(body EveryTypeOptional) Response {
+	return Response{
 		Body:        body,
 		Code:        200,
 		ContentType: "application/json",
@@ -185,9 +185,9 @@ func GetEveryTypeOptionalJSON200Response(body EveryTypeOptional) *Response {
 }
 
 // GetSimpleJSON200Response is a constructor method for a GetSimple response.
-// A *Response is returned with the configured status code and content type from the spec.
-func GetSimpleJSON200Response(body SomeObject) *Response {
-	return &Response{
+// A Response is returned with the configured status code and content type from the spec.
+func GetSimpleJSON200Response(body SomeObject) Response {
+	return Response{
 		Body:        body,
 		Code:        200,
 		ContentType: "application/json",
@@ -195,11 +195,11 @@ func GetSimpleJSON200Response(body SomeObject) *Response {
 }
 
 // GetWithArgsJSON200Response is a constructor method for a GetWithArgs response.
-// A *Response is returned with the configured status code and content type from the spec.
+// A Response is returned with the configured status code and content type from the spec.
 func GetWithArgsJSON200Response(body struct {
 	Name string `json:"name"`
-}) *Response {
-	return &Response{
+}) Response {
+	return Response{
 		Body:        body,
 		Code:        200,
 		ContentType: "application/json",
@@ -207,11 +207,11 @@ func GetWithArgsJSON200Response(body struct {
 }
 
 // GetWithReferencesJSON200Response is a constructor method for a GetWithReferences response.
-// A *Response is returned with the configured status code and content type from the spec.
+// A Response is returned with the configured status code and content type from the spec.
 func GetWithReferencesJSON200Response(body struct {
 	Name string `json:"name"`
-}) *Response {
-	return &Response{
+}) Response {
+	return Response{
 		Body:        body,
 		Code:        200,
 		ContentType: "application/json",
@@ -219,9 +219,9 @@ func GetWithReferencesJSON200Response(body struct {
 }
 
 // GetWithContentTypeJSON200Response is a constructor method for a GetWithContentType response.
-// A *Response is returned with the configured status code and content type from the spec.
-func GetWithContentTypeJSON200Response(body SomeObject) *Response {
-	return &Response{
+// A Response is returned with the configured status code and content type from the spec.
+func GetWithContentTypeJSON200Response(body SomeObject) Response {
+	return Response{
 		Body:        body,
 		Code:        200,
 		ContentType: "application/json",
@@ -229,9 +229,9 @@ func GetWithContentTypeJSON200Response(body SomeObject) *Response {
 }
 
 // GetReservedKeywordJSON200Response is a constructor method for a GetReservedKeyword response.
-// A *Response is returned with the configured status code and content type from the spec.
-func GetReservedKeywordJSON200Response(body ReservedKeyword) *Response {
-	return &Response{
+// A Response is returned with the configured status code and content type from the spec.
+func GetReservedKeywordJSON200Response(body ReservedKeyword) Response {
+	return Response{
 		Body:        body,
 		Code:        200,
 		ContentType: "application/json",
@@ -239,11 +239,11 @@ func GetReservedKeywordJSON200Response(body ReservedKeyword) *Response {
 }
 
 // CreateResourceJSON200Response is a constructor method for a CreateResource response.
-// A *Response is returned with the configured status code and content type from the spec.
+// A Response is returned with the configured status code and content type from the spec.
 func CreateResourceJSON200Response(body struct {
 	Name string `json:"name"`
-}) *Response {
-	return &Response{
+}) Response {
+	return Response{
 		Body:        body,
 		Code:        200,
 		ContentType: "application/json",
@@ -251,11 +251,11 @@ func CreateResourceJSON200Response(body struct {
 }
 
 // CreateResource2JSON200Response is a constructor method for a CreateResource2 response.
-// A *Response is returned with the configured status code and content type from the spec.
+// A Response is returned with the configured status code and content type from the spec.
 func CreateResource2JSON200Response(body struct {
 	Name string `json:"name"`
-}) *Response {
-	return &Response{
+}) Response {
+	return Response{
 		Body:        body,
 		Code:        200,
 		ContentType: "application/json",
@@ -263,11 +263,11 @@ func CreateResource2JSON200Response(body struct {
 }
 
 // UpdateResource3JSON200Response is a constructor method for a UpdateResource3 response.
-// A *Response is returned with the configured status code and content type from the spec.
+// A Response is returned with the configured status code and content type from the spec.
 func UpdateResource3JSON200Response(body struct {
 	Name string `json:"name"`
-}) *Response {
-	return &Response{
+}) Response {
+	return Response{
 		Body:        body,
 		Code:        200,
 		ContentType: "application/json",
@@ -275,9 +275,9 @@ func UpdateResource3JSON200Response(body struct {
 }
 
 // GetResponseWithReferenceJSON200Response is a constructor method for a GetResponseWithReference response.
-// A *Response is returned with the configured status code and content type from the spec.
-func GetResponseWithReferenceJSON200Response(body SomeObject) *Response {
-	return &Response{
+// A Response is returned with the configured status code and content type from the spec.
+func GetResponseWithReferenceJSON200Response(body SomeObject) Response {
+	return Response{
 		Body:        body,
 		Code:        200,
 		ContentType: "application/json",
@@ -285,11 +285,11 @@ func GetResponseWithReferenceJSON200Response(body SomeObject) *Response {
 }
 
 // GetWithTaggedMiddlewareJSON200Response is a constructor method for a GetWithTaggedMiddleware response.
-// A *Response is returned with the configured status code and content type from the spec.
+// A Response is returned with the configured status code and content type from the spec.
 func GetWithTaggedMiddlewareJSON200Response(body struct {
 	Name string `json:"name"`
-}) *Response {
-	return &Response{
+}) Response {
+	return Response{
 		Body:        body,
 		Code:        200,
 		ContentType: "application/json",
@@ -297,11 +297,11 @@ func GetWithTaggedMiddlewareJSON200Response(body struct {
 }
 
 // PostWithTaggedMiddlewareJSON200Response is a constructor method for a PostWithTaggedMiddleware response.
-// A *Response is returned with the configured status code and content type from the spec.
+// A Response is returned with the configured status code and content type from the spec.
 func PostWithTaggedMiddlewareJSON200Response(body struct {
 	Name string `json:"name"`
-}) *Response {
-	return &Response{
+}) Response {
+	return Response{
 		Body:        body,
 		Code:        200,
 		ContentType: "application/json",
@@ -363,6 +363,11 @@ func (siw *ServerInterfaceWrapper) GetEveryTypeOptional(w http.ResponseWriter, r
 	var handler = http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		resp := siw.Handler.GetEveryTypeOptional(w, r)
 		if resp != nil {
+			if resp, ok := resp.(Response); ok && resp.Body == nil {
+				w.WriteHeader(resp.Code)
+				return
+			}
+
 			render.Render(w, r, resp)
 		}
 	})
@@ -377,6 +382,11 @@ func (siw *ServerInterfaceWrapper) GetSimple(w http.ResponseWriter, r *http.Requ
 	var handler = http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		resp := siw.Handler.GetSimple(w, r)
 		if resp != nil {
+			if resp, ok := resp.(Response); ok && resp.Body == nil {
+				w.WriteHeader(resp.Code)
+				return
+			}
+
 			render.Render(w, r, resp)
 		}
 	})
@@ -430,6 +440,11 @@ func (siw *ServerInterfaceWrapper) GetWithArgs(w http.ResponseWriter, r *http.Re
 	var handler = http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		resp := siw.Handler.GetWithArgs(w, r, params)
 		if resp != nil {
+			if resp, ok := resp.(Response); ok && resp.Body == nil {
+				w.WriteHeader(resp.Code)
+				return
+			}
+
 			render.Render(w, r, resp)
 		}
 	})
@@ -460,6 +475,11 @@ func (siw *ServerInterfaceWrapper) GetWithReferences(w http.ResponseWriter, r *h
 	var handler = http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		resp := siw.Handler.GetWithReferences(w, r, globalArgument, argument)
 		if resp != nil {
+			if resp, ok := resp.(Response); ok && resp.Body == nil {
+				w.WriteHeader(resp.Code)
+				return
+			}
+
 			render.Render(w, r, resp)
 		}
 	})
@@ -482,6 +502,11 @@ func (siw *ServerInterfaceWrapper) GetWithContentType(w http.ResponseWriter, r *
 	var handler = http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		resp := siw.Handler.GetWithContentType(w, r, contentType)
 		if resp != nil {
+			if resp, ok := resp.(Response); ok && resp.Body == nil {
+				w.WriteHeader(resp.Code)
+				return
+			}
+
 			render.Render(w, r, resp)
 		}
 	})
@@ -496,6 +521,11 @@ func (siw *ServerInterfaceWrapper) GetReservedKeyword(w http.ResponseWriter, r *
 	var handler = http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		resp := siw.Handler.GetReservedKeyword(w, r)
 		if resp != nil {
+			if resp, ok := resp.(Response); ok && resp.Body == nil {
+				w.WriteHeader(resp.Code)
+				return
+			}
+
 			render.Render(w, r, resp)
 		}
 	})
@@ -518,6 +548,11 @@ func (siw *ServerInterfaceWrapper) CreateResource(w http.ResponseWriter, r *http
 	var handler = http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		resp := siw.Handler.CreateResource(w, r, argument)
 		if resp != nil {
+			if resp, ok := resp.(Response); ok && resp.Body == nil {
+				w.WriteHeader(resp.Code)
+				return
+			}
+
 			render.Render(w, r, resp)
 		}
 	})
@@ -551,6 +586,11 @@ func (siw *ServerInterfaceWrapper) CreateResource2(w http.ResponseWriter, r *htt
 	var handler = http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		resp := siw.Handler.CreateResource2(w, r, inlineArgument, params)
 		if resp != nil {
+			if resp, ok := resp.(Response); ok && resp.Body == nil {
+				w.WriteHeader(resp.Code)
+				return
+			}
+
 			render.Render(w, r, resp)
 		}
 	})
@@ -573,6 +613,11 @@ func (siw *ServerInterfaceWrapper) UpdateResource3(w http.ResponseWriter, r *htt
 	var handler = http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		resp := siw.Handler.UpdateResource3(w, r, pFallthrough)
 		if resp != nil {
+			if resp, ok := resp.(Response); ok && resp.Body == nil {
+				w.WriteHeader(resp.Code)
+				return
+			}
+
 			render.Render(w, r, resp)
 		}
 	})
@@ -587,6 +632,11 @@ func (siw *ServerInterfaceWrapper) GetResponseWithReference(w http.ResponseWrite
 	var handler = http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		resp := siw.Handler.GetResponseWithReference(w, r)
 		if resp != nil {
+			if resp, ok := resp.(Response); ok && resp.Body == nil {
+				w.WriteHeader(resp.Code)
+				return
+			}
+
 			render.Render(w, r, resp)
 		}
 	})
@@ -601,6 +651,11 @@ func (siw *ServerInterfaceWrapper) GetWithTaggedMiddleware(w http.ResponseWriter
 	var handler = http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		resp := siw.Handler.GetWithTaggedMiddleware(w, r)
 		if resp != nil {
+			if resp, ok := resp.(Response); ok && resp.Body == nil {
+				w.WriteHeader(resp.Code)
+				return
+			}
+
 			render.Render(w, r, resp)
 		}
 	})
@@ -618,6 +673,11 @@ func (siw *ServerInterfaceWrapper) PostWithTaggedMiddleware(w http.ResponseWrite
 	var handler = http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		resp := siw.Handler.PostWithTaggedMiddleware(w, r)
 		if resp != nil {
+			if resp, ok := resp.(Response); ok && resp.Body == nil {
+				w.WriteHeader(resp.Code)
+				return
+			}
+
 			render.Render(w, r, resp)
 		}
 	})

--- a/internal/test/server/server.gen.go
+++ b/internal/test/server/server.gen.go
@@ -145,19 +145,29 @@ func (UpdateResource3JSONRequestBody) Bind(*http.Request) error {
 	return nil
 }
 
+// Responser is an interface for responding to a request.
+type Responser interface {
+	Response() *Response
+}
+
 // Response is a common response struct for all the API calls.
 // A Response object may be instantiated via functions for specific operation responses.
 // It may also be instantiated directly, for the purpose of responding with a single status code.
 type Response struct {
-	body        interface{}
+	Body        interface{}
 	Code        int
-	contentType string
+	ContentType string
+}
+
+// Response implements the Responser interface.
+func (r *Response) Response() *Response {
+	return r
 }
 
 // Render implements the render.Renderer interface. It sets the Content-Type header
 // and status code based on the response definition.
 func (resp *Response) Render(w http.ResponseWriter, r *http.Request) error {
-	w.Header().Set("Content-Type", resp.contentType)
+	w.Header().Set("Content-Type", resp.ContentType)
 	render.Status(r, resp.Code)
 	return nil
 }
@@ -169,30 +179,30 @@ func (resp *Response) Status(code int) *Response {
 }
 
 // ContentType is a builder method to override the default content type for a response.
-func (resp *Response) ContentType(contentType string) *Response {
-	resp.contentType = contentType
+func (resp *Response) ContentTyp(contentType string) *Response {
+	resp.ContentType = contentType
 	return resp
 }
 
 // MarshalJSON implements the json.Marshaler interface.
 // This is used to only marshal the body of the response.
 func (resp *Response) MarshalJSON() ([]byte, error) {
-	return json.Marshal(resp.body)
+	return json.Marshal(resp.Body)
 }
 
 // MarshalXML implements the xml.Marshaler interface.
 // This is used to only marshal the body of the response.
 func (resp *Response) MarshalXML(e *xml.Encoder, start xml.StartElement) error {
-	return e.Encode(resp.body)
+	return e.Encode(resp.Body)
 }
 
 // GetEveryTypeOptionalJSON200Response is a constructor method for a GetEveryTypeOptional response.
 // A *Response is returned with the configured status code and content type from the spec.
 func GetEveryTypeOptionalJSON200Response(body EveryTypeOptional) *Response {
 	return &Response{
-		body:        body,
+		Body:        body,
 		Code:        200,
-		contentType: "application/json",
+		ContentType: "application/json",
 	}
 }
 
@@ -200,9 +210,9 @@ func GetEveryTypeOptionalJSON200Response(body EveryTypeOptional) *Response {
 // A *Response is returned with the configured status code and content type from the spec.
 func GetSimpleJSON200Response(body SomeObject) *Response {
 	return &Response{
-		body:        body,
+		Body:        body,
 		Code:        200,
-		contentType: "application/json",
+		ContentType: "application/json",
 	}
 }
 
@@ -212,9 +222,9 @@ func GetWithArgsJSON200Response(body struct {
 	Name string `json:"name"`
 }) *Response {
 	return &Response{
-		body:        body,
+		Body:        body,
 		Code:        200,
-		contentType: "application/json",
+		ContentType: "application/json",
 	}
 }
 
@@ -224,9 +234,9 @@ func GetWithReferencesJSON200Response(body struct {
 	Name string `json:"name"`
 }) *Response {
 	return &Response{
-		body:        body,
+		Body:        body,
 		Code:        200,
-		contentType: "application/json",
+		ContentType: "application/json",
 	}
 }
 
@@ -234,9 +244,9 @@ func GetWithReferencesJSON200Response(body struct {
 // A *Response is returned with the configured status code and content type from the spec.
 func GetWithContentTypeJSON200Response(body SomeObject) *Response {
 	return &Response{
-		body:        body,
+		Body:        body,
 		Code:        200,
-		contentType: "application/json",
+		ContentType: "application/json",
 	}
 }
 
@@ -244,9 +254,9 @@ func GetWithContentTypeJSON200Response(body SomeObject) *Response {
 // A *Response is returned with the configured status code and content type from the spec.
 func GetReservedKeywordJSON200Response(body ReservedKeyword) *Response {
 	return &Response{
-		body:        body,
+		Body:        body,
 		Code:        200,
-		contentType: "application/json",
+		ContentType: "application/json",
 	}
 }
 
@@ -256,9 +266,9 @@ func CreateResourceJSON200Response(body struct {
 	Name string `json:"name"`
 }) *Response {
 	return &Response{
-		body:        body,
+		Body:        body,
 		Code:        200,
-		contentType: "application/json",
+		ContentType: "application/json",
 	}
 }
 
@@ -268,9 +278,9 @@ func CreateResource2JSON200Response(body struct {
 	Name string `json:"name"`
 }) *Response {
 	return &Response{
-		body:        body,
+		Body:        body,
 		Code:        200,
-		contentType: "application/json",
+		ContentType: "application/json",
 	}
 }
 
@@ -280,9 +290,9 @@ func UpdateResource3JSON200Response(body struct {
 	Name string `json:"name"`
 }) *Response {
 	return &Response{
-		body:        body,
+		Body:        body,
 		Code:        200,
-		contentType: "application/json",
+		ContentType: "application/json",
 	}
 }
 
@@ -290,9 +300,9 @@ func UpdateResource3JSON200Response(body struct {
 // A *Response is returned with the configured status code and content type from the spec.
 func GetResponseWithReferenceJSON200Response(body SomeObject) *Response {
 	return &Response{
-		body:        body,
+		Body:        body,
 		Code:        200,
-		contentType: "application/json",
+		ContentType: "application/json",
 	}
 }
 
@@ -302,9 +312,9 @@ func GetWithTaggedMiddlewareJSON200Response(body struct {
 	Name string `json:"name"`
 }) *Response {
 	return &Response{
-		body:        body,
+		Body:        body,
 		Code:        200,
-		contentType: "application/json",
+		ContentType: "application/json",
 	}
 }
 
@@ -314,9 +324,9 @@ func PostWithTaggedMiddlewareJSON200Response(body struct {
 	Name string `json:"name"`
 }) *Response {
 	return &Response{
-		body:        body,
+		Body:        body,
 		Code:        200,
-		contentType: "application/json",
+		ContentType: "application/json",
 	}
 }
 
@@ -324,41 +334,41 @@ func PostWithTaggedMiddlewareJSON200Response(body struct {
 type ServerInterface interface {
 	// get every type optional
 	// (GET /every-type-optional)
-	GetEveryTypeOptional(w http.ResponseWriter, r *http.Request) *Response
+	GetEveryTypeOptional(w http.ResponseWriter, r *http.Request) Responser
 	// Get resource via simple path
 	// (GET /get-simple)
-	GetSimple(w http.ResponseWriter, r *http.Request) *Response
+	GetSimple(w http.ResponseWriter, r *http.Request) Responser
 	// Getter with referenced parameter and referenced response
 	// (GET /get-with-args)
-	GetWithArgs(w http.ResponseWriter, r *http.Request, params GetWithArgsParams) *Response
+	GetWithArgs(w http.ResponseWriter, r *http.Request, params GetWithArgsParams) Responser
 	// Getter with referenced parameter and referenced response
 	// (GET /get-with-references/{global_argument}/{argument})
-	GetWithReferences(w http.ResponseWriter, r *http.Request, globalArgument int64, argument Argument) *Response
+	GetWithReferences(w http.ResponseWriter, r *http.Request, globalArgument int64, argument Argument) Responser
 	// Get an object by ID
 	// (GET /get-with-type/{content_type})
-	GetWithContentType(w http.ResponseWriter, r *http.Request, contentType GetWithContentTypeParamsContentType) *Response
+	GetWithContentType(w http.ResponseWriter, r *http.Request, contentType GetWithContentTypeParamsContentType) Responser
 	// get with reserved keyword
 	// (GET /reserved-keyword)
-	GetReservedKeyword(w http.ResponseWriter, r *http.Request) *Response
+	GetReservedKeyword(w http.ResponseWriter, r *http.Request) Responser
 	// Create a resource
 	// (POST /resource/{argument})
-	CreateResource(w http.ResponseWriter, r *http.Request, argument Argument) *Response
+	CreateResource(w http.ResponseWriter, r *http.Request, argument Argument) Responser
 	// Create a resource with inline parameter
 	// (POST /resource2/{inline_argument})
-	CreateResource2(w http.ResponseWriter, r *http.Request, inlineArgument int, params CreateResource2Params) *Response
+	CreateResource2(w http.ResponseWriter, r *http.Request, inlineArgument int, params CreateResource2Params) Responser
 	// Update a resource with inline body. The parameter name is a reserved
 	// keyword, so make sure that gets prefixed to avoid syntax errors
 	// (PUT /resource3/{fallthrough})
-	UpdateResource3(w http.ResponseWriter, r *http.Request, pFallthrough int) *Response
+	UpdateResource3(w http.ResponseWriter, r *http.Request, pFallthrough int) Responser
 	// get response with reference
 	// (GET /response-with-reference)
-	GetResponseWithReference(w http.ResponseWriter, r *http.Request) *Response
+	GetResponseWithReference(w http.ResponseWriter, r *http.Request) Responser
 
 	// (GET /with-tagged-middleware)
-	GetWithTaggedMiddleware(w http.ResponseWriter, r *http.Request) *Response
+	GetWithTaggedMiddleware(w http.ResponseWriter, r *http.Request) Responser
 
 	// (POST /with-tagged-middleware)
-	PostWithTaggedMiddleware(w http.ResponseWriter, r *http.Request) *Response
+	PostWithTaggedMiddleware(w http.ResponseWriter, r *http.Request) Responser
 }
 
 // ServerInterfaceWrapper converts contexts to parameters.
@@ -375,10 +385,11 @@ func (siw *ServerInterfaceWrapper) GetEveryTypeOptional(w http.ResponseWriter, r
 	var handler = http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		resp := siw.Handler.GetEveryTypeOptional(w, r)
 		if resp != nil {
-			if resp.body != nil {
-				render.Render(w, r, resp)
+			rsp := resp.Response()
+			if rsp.Body != nil {
+				render.Render(w, r, rsp)
 			} else {
-				w.WriteHeader(resp.Code)
+				w.WriteHeader(rsp.Code)
 			}
 		}
 	})
@@ -393,10 +404,11 @@ func (siw *ServerInterfaceWrapper) GetSimple(w http.ResponseWriter, r *http.Requ
 	var handler = http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		resp := siw.Handler.GetSimple(w, r)
 		if resp != nil {
-			if resp.body != nil {
-				render.Render(w, r, resp)
+			rsp := resp.Response()
+			if rsp.Body != nil {
+				render.Render(w, r, rsp)
 			} else {
-				w.WriteHeader(resp.Code)
+				w.WriteHeader(rsp.Code)
 			}
 		}
 	})
@@ -450,10 +462,11 @@ func (siw *ServerInterfaceWrapper) GetWithArgs(w http.ResponseWriter, r *http.Re
 	var handler = http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		resp := siw.Handler.GetWithArgs(w, r, params)
 		if resp != nil {
-			if resp.body != nil {
-				render.Render(w, r, resp)
+			rsp := resp.Response()
+			if rsp.Body != nil {
+				render.Render(w, r, rsp)
 			} else {
-				w.WriteHeader(resp.Code)
+				w.WriteHeader(rsp.Code)
 			}
 		}
 	})
@@ -484,10 +497,11 @@ func (siw *ServerInterfaceWrapper) GetWithReferences(w http.ResponseWriter, r *h
 	var handler = http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		resp := siw.Handler.GetWithReferences(w, r, globalArgument, argument)
 		if resp != nil {
-			if resp.body != nil {
-				render.Render(w, r, resp)
+			rsp := resp.Response()
+			if rsp.Body != nil {
+				render.Render(w, r, rsp)
 			} else {
-				w.WriteHeader(resp.Code)
+				w.WriteHeader(rsp.Code)
 			}
 		}
 	})
@@ -510,10 +524,11 @@ func (siw *ServerInterfaceWrapper) GetWithContentType(w http.ResponseWriter, r *
 	var handler = http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		resp := siw.Handler.GetWithContentType(w, r, contentType)
 		if resp != nil {
-			if resp.body != nil {
-				render.Render(w, r, resp)
+			rsp := resp.Response()
+			if rsp.Body != nil {
+				render.Render(w, r, rsp)
 			} else {
-				w.WriteHeader(resp.Code)
+				w.WriteHeader(rsp.Code)
 			}
 		}
 	})
@@ -528,10 +543,11 @@ func (siw *ServerInterfaceWrapper) GetReservedKeyword(w http.ResponseWriter, r *
 	var handler = http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		resp := siw.Handler.GetReservedKeyword(w, r)
 		if resp != nil {
-			if resp.body != nil {
-				render.Render(w, r, resp)
+			rsp := resp.Response()
+			if rsp.Body != nil {
+				render.Render(w, r, rsp)
 			} else {
-				w.WriteHeader(resp.Code)
+				w.WriteHeader(rsp.Code)
 			}
 		}
 	})
@@ -554,10 +570,11 @@ func (siw *ServerInterfaceWrapper) CreateResource(w http.ResponseWriter, r *http
 	var handler = http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		resp := siw.Handler.CreateResource(w, r, argument)
 		if resp != nil {
-			if resp.body != nil {
-				render.Render(w, r, resp)
+			rsp := resp.Response()
+			if rsp.Body != nil {
+				render.Render(w, r, rsp)
 			} else {
-				w.WriteHeader(resp.Code)
+				w.WriteHeader(rsp.Code)
 			}
 		}
 	})
@@ -591,10 +608,11 @@ func (siw *ServerInterfaceWrapper) CreateResource2(w http.ResponseWriter, r *htt
 	var handler = http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		resp := siw.Handler.CreateResource2(w, r, inlineArgument, params)
 		if resp != nil {
-			if resp.body != nil {
-				render.Render(w, r, resp)
+			rsp := resp.Response()
+			if rsp.Body != nil {
+				render.Render(w, r, rsp)
 			} else {
-				w.WriteHeader(resp.Code)
+				w.WriteHeader(rsp.Code)
 			}
 		}
 	})
@@ -617,10 +635,11 @@ func (siw *ServerInterfaceWrapper) UpdateResource3(w http.ResponseWriter, r *htt
 	var handler = http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		resp := siw.Handler.UpdateResource3(w, r, pFallthrough)
 		if resp != nil {
-			if resp.body != nil {
-				render.Render(w, r, resp)
+			rsp := resp.Response()
+			if rsp.Body != nil {
+				render.Render(w, r, rsp)
 			} else {
-				w.WriteHeader(resp.Code)
+				w.WriteHeader(rsp.Code)
 			}
 		}
 	})
@@ -635,10 +654,11 @@ func (siw *ServerInterfaceWrapper) GetResponseWithReference(w http.ResponseWrite
 	var handler = http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		resp := siw.Handler.GetResponseWithReference(w, r)
 		if resp != nil {
-			if resp.body != nil {
-				render.Render(w, r, resp)
+			rsp := resp.Response()
+			if rsp.Body != nil {
+				render.Render(w, r, rsp)
 			} else {
-				w.WriteHeader(resp.Code)
+				w.WriteHeader(rsp.Code)
 			}
 		}
 	})
@@ -653,10 +673,11 @@ func (siw *ServerInterfaceWrapper) GetWithTaggedMiddleware(w http.ResponseWriter
 	var handler = http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		resp := siw.Handler.GetWithTaggedMiddleware(w, r)
 		if resp != nil {
-			if resp.body != nil {
-				render.Render(w, r, resp)
+			rsp := resp.Response()
+			if rsp.Body != nil {
+				render.Render(w, r, rsp)
 			} else {
-				w.WriteHeader(resp.Code)
+				w.WriteHeader(rsp.Code)
 			}
 		}
 	})
@@ -674,10 +695,11 @@ func (siw *ServerInterfaceWrapper) PostWithTaggedMiddleware(w http.ResponseWrite
 	var handler = http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		resp := siw.Handler.PostWithTaggedMiddleware(w, r)
 		if resp != nil {
-			if resp.body != nil {
-				render.Render(w, r, resp)
+			rsp := resp.Response()
+			if rsp.Body != nil {
+				render.Render(w, r, rsp)
 			} else {
-				w.WriteHeader(resp.Code)
+				w.WriteHeader(rsp.Code)
 			}
 		}
 	})

--- a/internal/test/server/server.gen.go
+++ b/internal/test/server/server.gen.go
@@ -145,11 +145,6 @@ func (UpdateResource3JSONRequestBody) Bind(*http.Request) error {
 	return nil
 }
 
-// Responser is an interface for responding to a request.
-type Responser interface {
-	Response() *Response
-}
-
 // Response is a common response struct for all the API calls.
 // A Response object may be instantiated via functions for specific operation responses.
 // It may also be instantiated directly, for the purpose of responding with a single status code.
@@ -159,29 +154,12 @@ type Response struct {
 	ContentType string
 }
 
-// Response implements the Responser interface.
-func (r *Response) Response() *Response {
-	return r
-}
-
 // Render implements the render.Renderer interface. It sets the Content-Type header
 // and status code based on the response definition.
 func (resp *Response) Render(w http.ResponseWriter, r *http.Request) error {
 	w.Header().Set("Content-Type", resp.ContentType)
 	render.Status(r, resp.Code)
 	return nil
-}
-
-// Status is a builder method to override the default status code for a response.
-func (resp *Response) Status(code int) *Response {
-	resp.Code = code
-	return resp
-}
-
-// ContentType is a builder method to override the default content type for a response.
-func (resp *Response) ContentTyp(contentType string) *Response {
-	resp.ContentType = contentType
-	return resp
 }
 
 // MarshalJSON implements the json.Marshaler interface.
@@ -334,41 +312,41 @@ func PostWithTaggedMiddlewareJSON200Response(body struct {
 type ServerInterface interface {
 	// get every type optional
 	// (GET /every-type-optional)
-	GetEveryTypeOptional(w http.ResponseWriter, r *http.Request) Responser
+	GetEveryTypeOptional(w http.ResponseWriter, r *http.Request) render.Renderer
 	// Get resource via simple path
 	// (GET /get-simple)
-	GetSimple(w http.ResponseWriter, r *http.Request) Responser
+	GetSimple(w http.ResponseWriter, r *http.Request) render.Renderer
 	// Getter with referenced parameter and referenced response
 	// (GET /get-with-args)
-	GetWithArgs(w http.ResponseWriter, r *http.Request, params GetWithArgsParams) Responser
+	GetWithArgs(w http.ResponseWriter, r *http.Request, params GetWithArgsParams) render.Renderer
 	// Getter with referenced parameter and referenced response
 	// (GET /get-with-references/{global_argument}/{argument})
-	GetWithReferences(w http.ResponseWriter, r *http.Request, globalArgument int64, argument Argument) Responser
+	GetWithReferences(w http.ResponseWriter, r *http.Request, globalArgument int64, argument Argument) render.Renderer
 	// Get an object by ID
 	// (GET /get-with-type/{content_type})
-	GetWithContentType(w http.ResponseWriter, r *http.Request, contentType GetWithContentTypeParamsContentType) Responser
+	GetWithContentType(w http.ResponseWriter, r *http.Request, contentType GetWithContentTypeParamsContentType) render.Renderer
 	// get with reserved keyword
 	// (GET /reserved-keyword)
-	GetReservedKeyword(w http.ResponseWriter, r *http.Request) Responser
+	GetReservedKeyword(w http.ResponseWriter, r *http.Request) render.Renderer
 	// Create a resource
 	// (POST /resource/{argument})
-	CreateResource(w http.ResponseWriter, r *http.Request, argument Argument) Responser
+	CreateResource(w http.ResponseWriter, r *http.Request, argument Argument) render.Renderer
 	// Create a resource with inline parameter
 	// (POST /resource2/{inline_argument})
-	CreateResource2(w http.ResponseWriter, r *http.Request, inlineArgument int, params CreateResource2Params) Responser
+	CreateResource2(w http.ResponseWriter, r *http.Request, inlineArgument int, params CreateResource2Params) render.Renderer
 	// Update a resource with inline body. The parameter name is a reserved
 	// keyword, so make sure that gets prefixed to avoid syntax errors
 	// (PUT /resource3/{fallthrough})
-	UpdateResource3(w http.ResponseWriter, r *http.Request, pFallthrough int) Responser
+	UpdateResource3(w http.ResponseWriter, r *http.Request, pFallthrough int) render.Renderer
 	// get response with reference
 	// (GET /response-with-reference)
-	GetResponseWithReference(w http.ResponseWriter, r *http.Request) Responser
+	GetResponseWithReference(w http.ResponseWriter, r *http.Request) render.Renderer
 
 	// (GET /with-tagged-middleware)
-	GetWithTaggedMiddleware(w http.ResponseWriter, r *http.Request) Responser
+	GetWithTaggedMiddleware(w http.ResponseWriter, r *http.Request) render.Renderer
 
 	// (POST /with-tagged-middleware)
-	PostWithTaggedMiddleware(w http.ResponseWriter, r *http.Request) Responser
+	PostWithTaggedMiddleware(w http.ResponseWriter, r *http.Request) render.Renderer
 }
 
 // ServerInterfaceWrapper converts contexts to parameters.
@@ -385,12 +363,7 @@ func (siw *ServerInterfaceWrapper) GetEveryTypeOptional(w http.ResponseWriter, r
 	var handler = http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		resp := siw.Handler.GetEveryTypeOptional(w, r)
 		if resp != nil {
-			rsp := resp.Response()
-			if rsp.Body != nil {
-				render.Render(w, r, rsp)
-			} else {
-				w.WriteHeader(rsp.Code)
-			}
+			render.Render(w, r, resp)
 		}
 	})
 
@@ -404,12 +377,7 @@ func (siw *ServerInterfaceWrapper) GetSimple(w http.ResponseWriter, r *http.Requ
 	var handler = http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		resp := siw.Handler.GetSimple(w, r)
 		if resp != nil {
-			rsp := resp.Response()
-			if rsp.Body != nil {
-				render.Render(w, r, rsp)
-			} else {
-				w.WriteHeader(rsp.Code)
-			}
+			render.Render(w, r, resp)
 		}
 	})
 
@@ -462,12 +430,7 @@ func (siw *ServerInterfaceWrapper) GetWithArgs(w http.ResponseWriter, r *http.Re
 	var handler = http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		resp := siw.Handler.GetWithArgs(w, r, params)
 		if resp != nil {
-			rsp := resp.Response()
-			if rsp.Body != nil {
-				render.Render(w, r, rsp)
-			} else {
-				w.WriteHeader(rsp.Code)
-			}
+			render.Render(w, r, resp)
 		}
 	})
 
@@ -497,12 +460,7 @@ func (siw *ServerInterfaceWrapper) GetWithReferences(w http.ResponseWriter, r *h
 	var handler = http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		resp := siw.Handler.GetWithReferences(w, r, globalArgument, argument)
 		if resp != nil {
-			rsp := resp.Response()
-			if rsp.Body != nil {
-				render.Render(w, r, rsp)
-			} else {
-				w.WriteHeader(rsp.Code)
-			}
+			render.Render(w, r, resp)
 		}
 	})
 
@@ -524,12 +482,7 @@ func (siw *ServerInterfaceWrapper) GetWithContentType(w http.ResponseWriter, r *
 	var handler = http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		resp := siw.Handler.GetWithContentType(w, r, contentType)
 		if resp != nil {
-			rsp := resp.Response()
-			if rsp.Body != nil {
-				render.Render(w, r, rsp)
-			} else {
-				w.WriteHeader(rsp.Code)
-			}
+			render.Render(w, r, resp)
 		}
 	})
 
@@ -543,12 +496,7 @@ func (siw *ServerInterfaceWrapper) GetReservedKeyword(w http.ResponseWriter, r *
 	var handler = http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		resp := siw.Handler.GetReservedKeyword(w, r)
 		if resp != nil {
-			rsp := resp.Response()
-			if rsp.Body != nil {
-				render.Render(w, r, rsp)
-			} else {
-				w.WriteHeader(rsp.Code)
-			}
+			render.Render(w, r, resp)
 		}
 	})
 
@@ -570,12 +518,7 @@ func (siw *ServerInterfaceWrapper) CreateResource(w http.ResponseWriter, r *http
 	var handler = http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		resp := siw.Handler.CreateResource(w, r, argument)
 		if resp != nil {
-			rsp := resp.Response()
-			if rsp.Body != nil {
-				render.Render(w, r, rsp)
-			} else {
-				w.WriteHeader(rsp.Code)
-			}
+			render.Render(w, r, resp)
 		}
 	})
 
@@ -608,12 +551,7 @@ func (siw *ServerInterfaceWrapper) CreateResource2(w http.ResponseWriter, r *htt
 	var handler = http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		resp := siw.Handler.CreateResource2(w, r, inlineArgument, params)
 		if resp != nil {
-			rsp := resp.Response()
-			if rsp.Body != nil {
-				render.Render(w, r, rsp)
-			} else {
-				w.WriteHeader(rsp.Code)
-			}
+			render.Render(w, r, resp)
 		}
 	})
 
@@ -635,12 +573,7 @@ func (siw *ServerInterfaceWrapper) UpdateResource3(w http.ResponseWriter, r *htt
 	var handler = http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		resp := siw.Handler.UpdateResource3(w, r, pFallthrough)
 		if resp != nil {
-			rsp := resp.Response()
-			if rsp.Body != nil {
-				render.Render(w, r, rsp)
-			} else {
-				w.WriteHeader(rsp.Code)
-			}
+			render.Render(w, r, resp)
 		}
 	})
 
@@ -654,12 +587,7 @@ func (siw *ServerInterfaceWrapper) GetResponseWithReference(w http.ResponseWrite
 	var handler = http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		resp := siw.Handler.GetResponseWithReference(w, r)
 		if resp != nil {
-			rsp := resp.Response()
-			if rsp.Body != nil {
-				render.Render(w, r, rsp)
-			} else {
-				w.WriteHeader(rsp.Code)
-			}
+			render.Render(w, r, resp)
 		}
 	})
 
@@ -673,12 +601,7 @@ func (siw *ServerInterfaceWrapper) GetWithTaggedMiddleware(w http.ResponseWriter
 	var handler = http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		resp := siw.Handler.GetWithTaggedMiddleware(w, r)
 		if resp != nil {
-			rsp := resp.Response()
-			if rsp.Body != nil {
-				render.Render(w, r, rsp)
-			} else {
-				w.WriteHeader(rsp.Code)
-			}
+			render.Render(w, r, resp)
 		}
 	})
 
@@ -695,12 +618,7 @@ func (siw *ServerInterfaceWrapper) PostWithTaggedMiddleware(w http.ResponseWrite
 	var handler = http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		resp := siw.Handler.PostWithTaggedMiddleware(w, r)
 		if resp != nil {
-			rsp := resp.Response()
-			if rsp.Body != nil {
-				render.Render(w, r, rsp)
-			} else {
-				w.WriteHeader(rsp.Code)
-			}
+			render.Render(w, r, resp)
 		}
 	})
 

--- a/internal/test/server/server_moq.gen.go
+++ b/internal/test/server/server_moq.gen.go
@@ -14,88 +14,88 @@ var _ ServerInterface = &ServerInterfaceMock{}
 
 // ServerInterfaceMock is a mock implementation of ServerInterface.
 //
-// 	func TestSomethingThatUsesServerInterface(t *testing.T) {
+//	func TestSomethingThatUsesServerInterface(t *testing.T) {
 //
-// 		// make and configure a mocked ServerInterface
-// 		mockedServerInterface := &ServerInterfaceMock{
-// 			CreateResourceFunc: func(w http.ResponseWriter, r *http.Request, argument Argument) *Response {
-// 				panic("mock out the CreateResource method")
-// 			},
-// 			CreateResource2Func: func(w http.ResponseWriter, r *http.Request, inlineArgument int, params CreateResource2Params) *Response {
-// 				panic("mock out the CreateResource2 method")
-// 			},
-// 			GetEveryTypeOptionalFunc: func(w http.ResponseWriter, r *http.Request) *Response {
-// 				panic("mock out the GetEveryTypeOptional method")
-// 			},
-// 			GetReservedKeywordFunc: func(w http.ResponseWriter, r *http.Request) *Response {
-// 				panic("mock out the GetReservedKeyword method")
-// 			},
-// 			GetResponseWithReferenceFunc: func(w http.ResponseWriter, r *http.Request) *Response {
-// 				panic("mock out the GetResponseWithReference method")
-// 			},
-// 			GetSimpleFunc: func(w http.ResponseWriter, r *http.Request) *Response {
-// 				panic("mock out the GetSimple method")
-// 			},
-// 			GetWithArgsFunc: func(w http.ResponseWriter, r *http.Request, params GetWithArgsParams) *Response {
-// 				panic("mock out the GetWithArgs method")
-// 			},
-// 			GetWithContentTypeFunc: func(w http.ResponseWriter, r *http.Request, contentType GetWithContentTypeParamsContentType) *Response {
-// 				panic("mock out the GetWithContentType method")
-// 			},
-// 			GetWithReferencesFunc: func(w http.ResponseWriter, r *http.Request, globalArgument int64, argument Argument) *Response {
-// 				panic("mock out the GetWithReferences method")
-// 			},
-// 			GetWithTaggedMiddlewareFunc: func(w http.ResponseWriter, r *http.Request) *Response {
-// 				panic("mock out the GetWithTaggedMiddleware method")
-// 			},
-// 			PostWithTaggedMiddlewareFunc: func(w http.ResponseWriter, r *http.Request) *Response {
-// 				panic("mock out the PostWithTaggedMiddleware method")
-// 			},
-// 			UpdateResource3Func: func(w http.ResponseWriter, r *http.Request, pFallthrough int) *Response {
-// 				panic("mock out the UpdateResource3 method")
-// 			},
-// 		}
+//		// make and configure a mocked ServerInterface
+//		mockedServerInterface := &ServerInterfaceMock{
+//			CreateResourceFunc: func(w http.ResponseWriter, r *http.Request, argument Argument) Responser {
+//				panic("mock out the CreateResource method")
+//			},
+//			CreateResource2Func: func(w http.ResponseWriter, r *http.Request, inlineArgument int, params CreateResource2Params) Responser {
+//				panic("mock out the CreateResource2 method")
+//			},
+//			GetEveryTypeOptionalFunc: func(w http.ResponseWriter, r *http.Request) Responser {
+//				panic("mock out the GetEveryTypeOptional method")
+//			},
+//			GetReservedKeywordFunc: func(w http.ResponseWriter, r *http.Request) Responser {
+//				panic("mock out the GetReservedKeyword method")
+//			},
+//			GetResponseWithReferenceFunc: func(w http.ResponseWriter, r *http.Request) Responser {
+//				panic("mock out the GetResponseWithReference method")
+//			},
+//			GetSimpleFunc: func(w http.ResponseWriter, r *http.Request) Responser {
+//				panic("mock out the GetSimple method")
+//			},
+//			GetWithArgsFunc: func(w http.ResponseWriter, r *http.Request, params GetWithArgsParams) Responser {
+//				panic("mock out the GetWithArgs method")
+//			},
+//			GetWithContentTypeFunc: func(w http.ResponseWriter, r *http.Request, contentType GetWithContentTypeParamsContentType) Responser {
+//				panic("mock out the GetWithContentType method")
+//			},
+//			GetWithReferencesFunc: func(w http.ResponseWriter, r *http.Request, globalArgument int64, argument Argument) Responser {
+//				panic("mock out the GetWithReferences method")
+//			},
+//			GetWithTaggedMiddlewareFunc: func(w http.ResponseWriter, r *http.Request) Responser {
+//				panic("mock out the GetWithTaggedMiddleware method")
+//			},
+//			PostWithTaggedMiddlewareFunc: func(w http.ResponseWriter, r *http.Request) Responser {
+//				panic("mock out the PostWithTaggedMiddleware method")
+//			},
+//			UpdateResource3Func: func(w http.ResponseWriter, r *http.Request, pFallthrough int) Responser {
+//				panic("mock out the UpdateResource3 method")
+//			},
+//		}
 //
-// 		// use mockedServerInterface in code that requires ServerInterface
-// 		// and then make assertions.
+//		// use mockedServerInterface in code that requires ServerInterface
+//		// and then make assertions.
 //
-// 	}
+//	}
 type ServerInterfaceMock struct {
 	// CreateResourceFunc mocks the CreateResource method.
-	CreateResourceFunc func(w http.ResponseWriter, r *http.Request, argument Argument) *Response
+	CreateResourceFunc func(w http.ResponseWriter, r *http.Request, argument Argument) Responser
 
 	// CreateResource2Func mocks the CreateResource2 method.
-	CreateResource2Func func(w http.ResponseWriter, r *http.Request, inlineArgument int, params CreateResource2Params) *Response
+	CreateResource2Func func(w http.ResponseWriter, r *http.Request, inlineArgument int, params CreateResource2Params) Responser
 
 	// GetEveryTypeOptionalFunc mocks the GetEveryTypeOptional method.
-	GetEveryTypeOptionalFunc func(w http.ResponseWriter, r *http.Request) *Response
+	GetEveryTypeOptionalFunc func(w http.ResponseWriter, r *http.Request) Responser
 
 	// GetReservedKeywordFunc mocks the GetReservedKeyword method.
-	GetReservedKeywordFunc func(w http.ResponseWriter, r *http.Request) *Response
+	GetReservedKeywordFunc func(w http.ResponseWriter, r *http.Request) Responser
 
 	// GetResponseWithReferenceFunc mocks the GetResponseWithReference method.
-	GetResponseWithReferenceFunc func(w http.ResponseWriter, r *http.Request) *Response
+	GetResponseWithReferenceFunc func(w http.ResponseWriter, r *http.Request) Responser
 
 	// GetSimpleFunc mocks the GetSimple method.
-	GetSimpleFunc func(w http.ResponseWriter, r *http.Request) *Response
+	GetSimpleFunc func(w http.ResponseWriter, r *http.Request) Responser
 
 	// GetWithArgsFunc mocks the GetWithArgs method.
-	GetWithArgsFunc func(w http.ResponseWriter, r *http.Request, params GetWithArgsParams) *Response
+	GetWithArgsFunc func(w http.ResponseWriter, r *http.Request, params GetWithArgsParams) Responser
 
 	// GetWithContentTypeFunc mocks the GetWithContentType method.
-	GetWithContentTypeFunc func(w http.ResponseWriter, r *http.Request, contentType GetWithContentTypeParamsContentType) *Response
+	GetWithContentTypeFunc func(w http.ResponseWriter, r *http.Request, contentType GetWithContentTypeParamsContentType) Responser
 
 	// GetWithReferencesFunc mocks the GetWithReferences method.
-	GetWithReferencesFunc func(w http.ResponseWriter, r *http.Request, globalArgument int64, argument Argument) *Response
+	GetWithReferencesFunc func(w http.ResponseWriter, r *http.Request, globalArgument int64, argument Argument) Responser
 
 	// GetWithTaggedMiddlewareFunc mocks the GetWithTaggedMiddleware method.
-	GetWithTaggedMiddlewareFunc func(w http.ResponseWriter, r *http.Request) *Response
+	GetWithTaggedMiddlewareFunc func(w http.ResponseWriter, r *http.Request) Responser
 
 	// PostWithTaggedMiddlewareFunc mocks the PostWithTaggedMiddleware method.
-	PostWithTaggedMiddlewareFunc func(w http.ResponseWriter, r *http.Request) *Response
+	PostWithTaggedMiddlewareFunc func(w http.ResponseWriter, r *http.Request) Responser
 
 	// UpdateResource3Func mocks the UpdateResource3 method.
-	UpdateResource3Func func(w http.ResponseWriter, r *http.Request, pFallthrough int) *Response
+	UpdateResource3Func func(w http.ResponseWriter, r *http.Request, pFallthrough int) Responser
 
 	// calls tracks calls to the methods.
 	calls struct {
@@ -215,7 +215,7 @@ type ServerInterfaceMock struct {
 }
 
 // CreateResource calls CreateResourceFunc.
-func (mock *ServerInterfaceMock) CreateResource(w http.ResponseWriter, r *http.Request, argument Argument) *Response {
+func (mock *ServerInterfaceMock) CreateResource(w http.ResponseWriter, r *http.Request, argument Argument) Responser {
 	if mock.CreateResourceFunc == nil {
 		panic("ServerInterfaceMock.CreateResourceFunc: method is nil but ServerInterface.CreateResource was just called")
 	}
@@ -236,7 +236,8 @@ func (mock *ServerInterfaceMock) CreateResource(w http.ResponseWriter, r *http.R
 
 // CreateResourceCalls gets all the calls that were made to CreateResource.
 // Check the length with:
-//     len(mockedServerInterface.CreateResourceCalls())
+//
+//	len(mockedServerInterface.CreateResourceCalls())
 func (mock *ServerInterfaceMock) CreateResourceCalls() []struct {
 	W        http.ResponseWriter
 	R        *http.Request
@@ -254,7 +255,7 @@ func (mock *ServerInterfaceMock) CreateResourceCalls() []struct {
 }
 
 // CreateResource2 calls CreateResource2Func.
-func (mock *ServerInterfaceMock) CreateResource2(w http.ResponseWriter, r *http.Request, inlineArgument int, params CreateResource2Params) *Response {
+func (mock *ServerInterfaceMock) CreateResource2(w http.ResponseWriter, r *http.Request, inlineArgument int, params CreateResource2Params) Responser {
 	if mock.CreateResource2Func == nil {
 		panic("ServerInterfaceMock.CreateResource2Func: method is nil but ServerInterface.CreateResource2 was just called")
 	}
@@ -277,7 +278,8 @@ func (mock *ServerInterfaceMock) CreateResource2(w http.ResponseWriter, r *http.
 
 // CreateResource2Calls gets all the calls that were made to CreateResource2.
 // Check the length with:
-//     len(mockedServerInterface.CreateResource2Calls())
+//
+//	len(mockedServerInterface.CreateResource2Calls())
 func (mock *ServerInterfaceMock) CreateResource2Calls() []struct {
 	W              http.ResponseWriter
 	R              *http.Request
@@ -297,7 +299,7 @@ func (mock *ServerInterfaceMock) CreateResource2Calls() []struct {
 }
 
 // GetEveryTypeOptional calls GetEveryTypeOptionalFunc.
-func (mock *ServerInterfaceMock) GetEveryTypeOptional(w http.ResponseWriter, r *http.Request) *Response {
+func (mock *ServerInterfaceMock) GetEveryTypeOptional(w http.ResponseWriter, r *http.Request) Responser {
 	if mock.GetEveryTypeOptionalFunc == nil {
 		panic("ServerInterfaceMock.GetEveryTypeOptionalFunc: method is nil but ServerInterface.GetEveryTypeOptional was just called")
 	}
@@ -316,7 +318,8 @@ func (mock *ServerInterfaceMock) GetEveryTypeOptional(w http.ResponseWriter, r *
 
 // GetEveryTypeOptionalCalls gets all the calls that were made to GetEveryTypeOptional.
 // Check the length with:
-//     len(mockedServerInterface.GetEveryTypeOptionalCalls())
+//
+//	len(mockedServerInterface.GetEveryTypeOptionalCalls())
 func (mock *ServerInterfaceMock) GetEveryTypeOptionalCalls() []struct {
 	W http.ResponseWriter
 	R *http.Request
@@ -332,7 +335,7 @@ func (mock *ServerInterfaceMock) GetEveryTypeOptionalCalls() []struct {
 }
 
 // GetReservedKeyword calls GetReservedKeywordFunc.
-func (mock *ServerInterfaceMock) GetReservedKeyword(w http.ResponseWriter, r *http.Request) *Response {
+func (mock *ServerInterfaceMock) GetReservedKeyword(w http.ResponseWriter, r *http.Request) Responser {
 	if mock.GetReservedKeywordFunc == nil {
 		panic("ServerInterfaceMock.GetReservedKeywordFunc: method is nil but ServerInterface.GetReservedKeyword was just called")
 	}
@@ -351,7 +354,8 @@ func (mock *ServerInterfaceMock) GetReservedKeyword(w http.ResponseWriter, r *ht
 
 // GetReservedKeywordCalls gets all the calls that were made to GetReservedKeyword.
 // Check the length with:
-//     len(mockedServerInterface.GetReservedKeywordCalls())
+//
+//	len(mockedServerInterface.GetReservedKeywordCalls())
 func (mock *ServerInterfaceMock) GetReservedKeywordCalls() []struct {
 	W http.ResponseWriter
 	R *http.Request
@@ -367,7 +371,7 @@ func (mock *ServerInterfaceMock) GetReservedKeywordCalls() []struct {
 }
 
 // GetResponseWithReference calls GetResponseWithReferenceFunc.
-func (mock *ServerInterfaceMock) GetResponseWithReference(w http.ResponseWriter, r *http.Request) *Response {
+func (mock *ServerInterfaceMock) GetResponseWithReference(w http.ResponseWriter, r *http.Request) Responser {
 	if mock.GetResponseWithReferenceFunc == nil {
 		panic("ServerInterfaceMock.GetResponseWithReferenceFunc: method is nil but ServerInterface.GetResponseWithReference was just called")
 	}
@@ -386,7 +390,8 @@ func (mock *ServerInterfaceMock) GetResponseWithReference(w http.ResponseWriter,
 
 // GetResponseWithReferenceCalls gets all the calls that were made to GetResponseWithReference.
 // Check the length with:
-//     len(mockedServerInterface.GetResponseWithReferenceCalls())
+//
+//	len(mockedServerInterface.GetResponseWithReferenceCalls())
 func (mock *ServerInterfaceMock) GetResponseWithReferenceCalls() []struct {
 	W http.ResponseWriter
 	R *http.Request
@@ -402,7 +407,7 @@ func (mock *ServerInterfaceMock) GetResponseWithReferenceCalls() []struct {
 }
 
 // GetSimple calls GetSimpleFunc.
-func (mock *ServerInterfaceMock) GetSimple(w http.ResponseWriter, r *http.Request) *Response {
+func (mock *ServerInterfaceMock) GetSimple(w http.ResponseWriter, r *http.Request) Responser {
 	if mock.GetSimpleFunc == nil {
 		panic("ServerInterfaceMock.GetSimpleFunc: method is nil but ServerInterface.GetSimple was just called")
 	}
@@ -421,7 +426,8 @@ func (mock *ServerInterfaceMock) GetSimple(w http.ResponseWriter, r *http.Reques
 
 // GetSimpleCalls gets all the calls that were made to GetSimple.
 // Check the length with:
-//     len(mockedServerInterface.GetSimpleCalls())
+//
+//	len(mockedServerInterface.GetSimpleCalls())
 func (mock *ServerInterfaceMock) GetSimpleCalls() []struct {
 	W http.ResponseWriter
 	R *http.Request
@@ -437,7 +443,7 @@ func (mock *ServerInterfaceMock) GetSimpleCalls() []struct {
 }
 
 // GetWithArgs calls GetWithArgsFunc.
-func (mock *ServerInterfaceMock) GetWithArgs(w http.ResponseWriter, r *http.Request, params GetWithArgsParams) *Response {
+func (mock *ServerInterfaceMock) GetWithArgs(w http.ResponseWriter, r *http.Request, params GetWithArgsParams) Responser {
 	if mock.GetWithArgsFunc == nil {
 		panic("ServerInterfaceMock.GetWithArgsFunc: method is nil but ServerInterface.GetWithArgs was just called")
 	}
@@ -458,7 +464,8 @@ func (mock *ServerInterfaceMock) GetWithArgs(w http.ResponseWriter, r *http.Requ
 
 // GetWithArgsCalls gets all the calls that were made to GetWithArgs.
 // Check the length with:
-//     len(mockedServerInterface.GetWithArgsCalls())
+//
+//	len(mockedServerInterface.GetWithArgsCalls())
 func (mock *ServerInterfaceMock) GetWithArgsCalls() []struct {
 	W      http.ResponseWriter
 	R      *http.Request
@@ -476,7 +483,7 @@ func (mock *ServerInterfaceMock) GetWithArgsCalls() []struct {
 }
 
 // GetWithContentType calls GetWithContentTypeFunc.
-func (mock *ServerInterfaceMock) GetWithContentType(w http.ResponseWriter, r *http.Request, contentType GetWithContentTypeParamsContentType) *Response {
+func (mock *ServerInterfaceMock) GetWithContentType(w http.ResponseWriter, r *http.Request, contentType GetWithContentTypeParamsContentType) Responser {
 	if mock.GetWithContentTypeFunc == nil {
 		panic("ServerInterfaceMock.GetWithContentTypeFunc: method is nil but ServerInterface.GetWithContentType was just called")
 	}
@@ -497,7 +504,8 @@ func (mock *ServerInterfaceMock) GetWithContentType(w http.ResponseWriter, r *ht
 
 // GetWithContentTypeCalls gets all the calls that were made to GetWithContentType.
 // Check the length with:
-//     len(mockedServerInterface.GetWithContentTypeCalls())
+//
+//	len(mockedServerInterface.GetWithContentTypeCalls())
 func (mock *ServerInterfaceMock) GetWithContentTypeCalls() []struct {
 	W           http.ResponseWriter
 	R           *http.Request
@@ -515,7 +523,7 @@ func (mock *ServerInterfaceMock) GetWithContentTypeCalls() []struct {
 }
 
 // GetWithReferences calls GetWithReferencesFunc.
-func (mock *ServerInterfaceMock) GetWithReferences(w http.ResponseWriter, r *http.Request, globalArgument int64, argument Argument) *Response {
+func (mock *ServerInterfaceMock) GetWithReferences(w http.ResponseWriter, r *http.Request, globalArgument int64, argument Argument) Responser {
 	if mock.GetWithReferencesFunc == nil {
 		panic("ServerInterfaceMock.GetWithReferencesFunc: method is nil but ServerInterface.GetWithReferences was just called")
 	}
@@ -538,7 +546,8 @@ func (mock *ServerInterfaceMock) GetWithReferences(w http.ResponseWriter, r *htt
 
 // GetWithReferencesCalls gets all the calls that were made to GetWithReferences.
 // Check the length with:
-//     len(mockedServerInterface.GetWithReferencesCalls())
+//
+//	len(mockedServerInterface.GetWithReferencesCalls())
 func (mock *ServerInterfaceMock) GetWithReferencesCalls() []struct {
 	W              http.ResponseWriter
 	R              *http.Request
@@ -558,7 +567,7 @@ func (mock *ServerInterfaceMock) GetWithReferencesCalls() []struct {
 }
 
 // GetWithTaggedMiddleware calls GetWithTaggedMiddlewareFunc.
-func (mock *ServerInterfaceMock) GetWithTaggedMiddleware(w http.ResponseWriter, r *http.Request) *Response {
+func (mock *ServerInterfaceMock) GetWithTaggedMiddleware(w http.ResponseWriter, r *http.Request) Responser {
 	if mock.GetWithTaggedMiddlewareFunc == nil {
 		panic("ServerInterfaceMock.GetWithTaggedMiddlewareFunc: method is nil but ServerInterface.GetWithTaggedMiddleware was just called")
 	}
@@ -577,7 +586,8 @@ func (mock *ServerInterfaceMock) GetWithTaggedMiddleware(w http.ResponseWriter, 
 
 // GetWithTaggedMiddlewareCalls gets all the calls that were made to GetWithTaggedMiddleware.
 // Check the length with:
-//     len(mockedServerInterface.GetWithTaggedMiddlewareCalls())
+//
+//	len(mockedServerInterface.GetWithTaggedMiddlewareCalls())
 func (mock *ServerInterfaceMock) GetWithTaggedMiddlewareCalls() []struct {
 	W http.ResponseWriter
 	R *http.Request
@@ -593,7 +603,7 @@ func (mock *ServerInterfaceMock) GetWithTaggedMiddlewareCalls() []struct {
 }
 
 // PostWithTaggedMiddleware calls PostWithTaggedMiddlewareFunc.
-func (mock *ServerInterfaceMock) PostWithTaggedMiddleware(w http.ResponseWriter, r *http.Request) *Response {
+func (mock *ServerInterfaceMock) PostWithTaggedMiddleware(w http.ResponseWriter, r *http.Request) Responser {
 	if mock.PostWithTaggedMiddlewareFunc == nil {
 		panic("ServerInterfaceMock.PostWithTaggedMiddlewareFunc: method is nil but ServerInterface.PostWithTaggedMiddleware was just called")
 	}
@@ -612,7 +622,8 @@ func (mock *ServerInterfaceMock) PostWithTaggedMiddleware(w http.ResponseWriter,
 
 // PostWithTaggedMiddlewareCalls gets all the calls that were made to PostWithTaggedMiddleware.
 // Check the length with:
-//     len(mockedServerInterface.PostWithTaggedMiddlewareCalls())
+//
+//	len(mockedServerInterface.PostWithTaggedMiddlewareCalls())
 func (mock *ServerInterfaceMock) PostWithTaggedMiddlewareCalls() []struct {
 	W http.ResponseWriter
 	R *http.Request
@@ -628,7 +639,7 @@ func (mock *ServerInterfaceMock) PostWithTaggedMiddlewareCalls() []struct {
 }
 
 // UpdateResource3 calls UpdateResource3Func.
-func (mock *ServerInterfaceMock) UpdateResource3(w http.ResponseWriter, r *http.Request, pFallthrough int) *Response {
+func (mock *ServerInterfaceMock) UpdateResource3(w http.ResponseWriter, r *http.Request, pFallthrough int) Responser {
 	if mock.UpdateResource3Func == nil {
 		panic("ServerInterfaceMock.UpdateResource3Func: method is nil but ServerInterface.UpdateResource3 was just called")
 	}
@@ -649,7 +660,8 @@ func (mock *ServerInterfaceMock) UpdateResource3(w http.ResponseWriter, r *http.
 
 // UpdateResource3Calls gets all the calls that were made to UpdateResource3.
 // Check the length with:
-//     len(mockedServerInterface.UpdateResource3Calls())
+//
+//	len(mockedServerInterface.UpdateResource3Calls())
 func (mock *ServerInterfaceMock) UpdateResource3Calls() []struct {
 	W            http.ResponseWriter
 	R            *http.Request

--- a/internal/test/server/server_moq.gen.go
+++ b/internal/test/server/server_moq.gen.go
@@ -4,6 +4,7 @@
 package server
 
 import (
+	"github.com/go-chi/render"
 	"net/http"
 	"sync"
 )
@@ -18,40 +19,40 @@ var _ ServerInterface = &ServerInterfaceMock{}
 //
 //		// make and configure a mocked ServerInterface
 //		mockedServerInterface := &ServerInterfaceMock{
-//			CreateResourceFunc: func(w http.ResponseWriter, r *http.Request, argument Argument) Responser {
+//			CreateResourceFunc: func(w http.ResponseWriter, r *http.Request, argument Argument) render.Renderer {
 //				panic("mock out the CreateResource method")
 //			},
-//			CreateResource2Func: func(w http.ResponseWriter, r *http.Request, inlineArgument int, params CreateResource2Params) Responser {
+//			CreateResource2Func: func(w http.ResponseWriter, r *http.Request, inlineArgument int, params CreateResource2Params) render.Renderer {
 //				panic("mock out the CreateResource2 method")
 //			},
-//			GetEveryTypeOptionalFunc: func(w http.ResponseWriter, r *http.Request) Responser {
+//			GetEveryTypeOptionalFunc: func(w http.ResponseWriter, r *http.Request) render.Renderer {
 //				panic("mock out the GetEveryTypeOptional method")
 //			},
-//			GetReservedKeywordFunc: func(w http.ResponseWriter, r *http.Request) Responser {
+//			GetReservedKeywordFunc: func(w http.ResponseWriter, r *http.Request) render.Renderer {
 //				panic("mock out the GetReservedKeyword method")
 //			},
-//			GetResponseWithReferenceFunc: func(w http.ResponseWriter, r *http.Request) Responser {
+//			GetResponseWithReferenceFunc: func(w http.ResponseWriter, r *http.Request) render.Renderer {
 //				panic("mock out the GetResponseWithReference method")
 //			},
-//			GetSimpleFunc: func(w http.ResponseWriter, r *http.Request) Responser {
+//			GetSimpleFunc: func(w http.ResponseWriter, r *http.Request) render.Renderer {
 //				panic("mock out the GetSimple method")
 //			},
-//			GetWithArgsFunc: func(w http.ResponseWriter, r *http.Request, params GetWithArgsParams) Responser {
+//			GetWithArgsFunc: func(w http.ResponseWriter, r *http.Request, params GetWithArgsParams) render.Renderer {
 //				panic("mock out the GetWithArgs method")
 //			},
-//			GetWithContentTypeFunc: func(w http.ResponseWriter, r *http.Request, contentType GetWithContentTypeParamsContentType) Responser {
+//			GetWithContentTypeFunc: func(w http.ResponseWriter, r *http.Request, contentType GetWithContentTypeParamsContentType) render.Renderer {
 //				panic("mock out the GetWithContentType method")
 //			},
-//			GetWithReferencesFunc: func(w http.ResponseWriter, r *http.Request, globalArgument int64, argument Argument) Responser {
+//			GetWithReferencesFunc: func(w http.ResponseWriter, r *http.Request, globalArgument int64, argument Argument) render.Renderer {
 //				panic("mock out the GetWithReferences method")
 //			},
-//			GetWithTaggedMiddlewareFunc: func(w http.ResponseWriter, r *http.Request) Responser {
+//			GetWithTaggedMiddlewareFunc: func(w http.ResponseWriter, r *http.Request) render.Renderer {
 //				panic("mock out the GetWithTaggedMiddleware method")
 //			},
-//			PostWithTaggedMiddlewareFunc: func(w http.ResponseWriter, r *http.Request) Responser {
+//			PostWithTaggedMiddlewareFunc: func(w http.ResponseWriter, r *http.Request) render.Renderer {
 //				panic("mock out the PostWithTaggedMiddleware method")
 //			},
-//			UpdateResource3Func: func(w http.ResponseWriter, r *http.Request, pFallthrough int) Responser {
+//			UpdateResource3Func: func(w http.ResponseWriter, r *http.Request, pFallthrough int) render.Renderer {
 //				panic("mock out the UpdateResource3 method")
 //			},
 //		}
@@ -62,40 +63,40 @@ var _ ServerInterface = &ServerInterfaceMock{}
 //	}
 type ServerInterfaceMock struct {
 	// CreateResourceFunc mocks the CreateResource method.
-	CreateResourceFunc func(w http.ResponseWriter, r *http.Request, argument Argument) Responser
+	CreateResourceFunc func(w http.ResponseWriter, r *http.Request, argument Argument) render.Renderer
 
 	// CreateResource2Func mocks the CreateResource2 method.
-	CreateResource2Func func(w http.ResponseWriter, r *http.Request, inlineArgument int, params CreateResource2Params) Responser
+	CreateResource2Func func(w http.ResponseWriter, r *http.Request, inlineArgument int, params CreateResource2Params) render.Renderer
 
 	// GetEveryTypeOptionalFunc mocks the GetEveryTypeOptional method.
-	GetEveryTypeOptionalFunc func(w http.ResponseWriter, r *http.Request) Responser
+	GetEveryTypeOptionalFunc func(w http.ResponseWriter, r *http.Request) render.Renderer
 
 	// GetReservedKeywordFunc mocks the GetReservedKeyword method.
-	GetReservedKeywordFunc func(w http.ResponseWriter, r *http.Request) Responser
+	GetReservedKeywordFunc func(w http.ResponseWriter, r *http.Request) render.Renderer
 
 	// GetResponseWithReferenceFunc mocks the GetResponseWithReference method.
-	GetResponseWithReferenceFunc func(w http.ResponseWriter, r *http.Request) Responser
+	GetResponseWithReferenceFunc func(w http.ResponseWriter, r *http.Request) render.Renderer
 
 	// GetSimpleFunc mocks the GetSimple method.
-	GetSimpleFunc func(w http.ResponseWriter, r *http.Request) Responser
+	GetSimpleFunc func(w http.ResponseWriter, r *http.Request) render.Renderer
 
 	// GetWithArgsFunc mocks the GetWithArgs method.
-	GetWithArgsFunc func(w http.ResponseWriter, r *http.Request, params GetWithArgsParams) Responser
+	GetWithArgsFunc func(w http.ResponseWriter, r *http.Request, params GetWithArgsParams) render.Renderer
 
 	// GetWithContentTypeFunc mocks the GetWithContentType method.
-	GetWithContentTypeFunc func(w http.ResponseWriter, r *http.Request, contentType GetWithContentTypeParamsContentType) Responser
+	GetWithContentTypeFunc func(w http.ResponseWriter, r *http.Request, contentType GetWithContentTypeParamsContentType) render.Renderer
 
 	// GetWithReferencesFunc mocks the GetWithReferences method.
-	GetWithReferencesFunc func(w http.ResponseWriter, r *http.Request, globalArgument int64, argument Argument) Responser
+	GetWithReferencesFunc func(w http.ResponseWriter, r *http.Request, globalArgument int64, argument Argument) render.Renderer
 
 	// GetWithTaggedMiddlewareFunc mocks the GetWithTaggedMiddleware method.
-	GetWithTaggedMiddlewareFunc func(w http.ResponseWriter, r *http.Request) Responser
+	GetWithTaggedMiddlewareFunc func(w http.ResponseWriter, r *http.Request) render.Renderer
 
 	// PostWithTaggedMiddlewareFunc mocks the PostWithTaggedMiddleware method.
-	PostWithTaggedMiddlewareFunc func(w http.ResponseWriter, r *http.Request) Responser
+	PostWithTaggedMiddlewareFunc func(w http.ResponseWriter, r *http.Request) render.Renderer
 
 	// UpdateResource3Func mocks the UpdateResource3 method.
-	UpdateResource3Func func(w http.ResponseWriter, r *http.Request, pFallthrough int) Responser
+	UpdateResource3Func func(w http.ResponseWriter, r *http.Request, pFallthrough int) render.Renderer
 
 	// calls tracks calls to the methods.
 	calls struct {
@@ -215,7 +216,7 @@ type ServerInterfaceMock struct {
 }
 
 // CreateResource calls CreateResourceFunc.
-func (mock *ServerInterfaceMock) CreateResource(w http.ResponseWriter, r *http.Request, argument Argument) Responser {
+func (mock *ServerInterfaceMock) CreateResource(w http.ResponseWriter, r *http.Request, argument Argument) render.Renderer {
 	if mock.CreateResourceFunc == nil {
 		panic("ServerInterfaceMock.CreateResourceFunc: method is nil but ServerInterface.CreateResource was just called")
 	}
@@ -255,7 +256,7 @@ func (mock *ServerInterfaceMock) CreateResourceCalls() []struct {
 }
 
 // CreateResource2 calls CreateResource2Func.
-func (mock *ServerInterfaceMock) CreateResource2(w http.ResponseWriter, r *http.Request, inlineArgument int, params CreateResource2Params) Responser {
+func (mock *ServerInterfaceMock) CreateResource2(w http.ResponseWriter, r *http.Request, inlineArgument int, params CreateResource2Params) render.Renderer {
 	if mock.CreateResource2Func == nil {
 		panic("ServerInterfaceMock.CreateResource2Func: method is nil but ServerInterface.CreateResource2 was just called")
 	}
@@ -299,7 +300,7 @@ func (mock *ServerInterfaceMock) CreateResource2Calls() []struct {
 }
 
 // GetEveryTypeOptional calls GetEveryTypeOptionalFunc.
-func (mock *ServerInterfaceMock) GetEveryTypeOptional(w http.ResponseWriter, r *http.Request) Responser {
+func (mock *ServerInterfaceMock) GetEveryTypeOptional(w http.ResponseWriter, r *http.Request) render.Renderer {
 	if mock.GetEveryTypeOptionalFunc == nil {
 		panic("ServerInterfaceMock.GetEveryTypeOptionalFunc: method is nil but ServerInterface.GetEveryTypeOptional was just called")
 	}
@@ -335,7 +336,7 @@ func (mock *ServerInterfaceMock) GetEveryTypeOptionalCalls() []struct {
 }
 
 // GetReservedKeyword calls GetReservedKeywordFunc.
-func (mock *ServerInterfaceMock) GetReservedKeyword(w http.ResponseWriter, r *http.Request) Responser {
+func (mock *ServerInterfaceMock) GetReservedKeyword(w http.ResponseWriter, r *http.Request) render.Renderer {
 	if mock.GetReservedKeywordFunc == nil {
 		panic("ServerInterfaceMock.GetReservedKeywordFunc: method is nil but ServerInterface.GetReservedKeyword was just called")
 	}
@@ -371,7 +372,7 @@ func (mock *ServerInterfaceMock) GetReservedKeywordCalls() []struct {
 }
 
 // GetResponseWithReference calls GetResponseWithReferenceFunc.
-func (mock *ServerInterfaceMock) GetResponseWithReference(w http.ResponseWriter, r *http.Request) Responser {
+func (mock *ServerInterfaceMock) GetResponseWithReference(w http.ResponseWriter, r *http.Request) render.Renderer {
 	if mock.GetResponseWithReferenceFunc == nil {
 		panic("ServerInterfaceMock.GetResponseWithReferenceFunc: method is nil but ServerInterface.GetResponseWithReference was just called")
 	}
@@ -407,7 +408,7 @@ func (mock *ServerInterfaceMock) GetResponseWithReferenceCalls() []struct {
 }
 
 // GetSimple calls GetSimpleFunc.
-func (mock *ServerInterfaceMock) GetSimple(w http.ResponseWriter, r *http.Request) Responser {
+func (mock *ServerInterfaceMock) GetSimple(w http.ResponseWriter, r *http.Request) render.Renderer {
 	if mock.GetSimpleFunc == nil {
 		panic("ServerInterfaceMock.GetSimpleFunc: method is nil but ServerInterface.GetSimple was just called")
 	}
@@ -443,7 +444,7 @@ func (mock *ServerInterfaceMock) GetSimpleCalls() []struct {
 }
 
 // GetWithArgs calls GetWithArgsFunc.
-func (mock *ServerInterfaceMock) GetWithArgs(w http.ResponseWriter, r *http.Request, params GetWithArgsParams) Responser {
+func (mock *ServerInterfaceMock) GetWithArgs(w http.ResponseWriter, r *http.Request, params GetWithArgsParams) render.Renderer {
 	if mock.GetWithArgsFunc == nil {
 		panic("ServerInterfaceMock.GetWithArgsFunc: method is nil but ServerInterface.GetWithArgs was just called")
 	}
@@ -483,7 +484,7 @@ func (mock *ServerInterfaceMock) GetWithArgsCalls() []struct {
 }
 
 // GetWithContentType calls GetWithContentTypeFunc.
-func (mock *ServerInterfaceMock) GetWithContentType(w http.ResponseWriter, r *http.Request, contentType GetWithContentTypeParamsContentType) Responser {
+func (mock *ServerInterfaceMock) GetWithContentType(w http.ResponseWriter, r *http.Request, contentType GetWithContentTypeParamsContentType) render.Renderer {
 	if mock.GetWithContentTypeFunc == nil {
 		panic("ServerInterfaceMock.GetWithContentTypeFunc: method is nil but ServerInterface.GetWithContentType was just called")
 	}
@@ -523,7 +524,7 @@ func (mock *ServerInterfaceMock) GetWithContentTypeCalls() []struct {
 }
 
 // GetWithReferences calls GetWithReferencesFunc.
-func (mock *ServerInterfaceMock) GetWithReferences(w http.ResponseWriter, r *http.Request, globalArgument int64, argument Argument) Responser {
+func (mock *ServerInterfaceMock) GetWithReferences(w http.ResponseWriter, r *http.Request, globalArgument int64, argument Argument) render.Renderer {
 	if mock.GetWithReferencesFunc == nil {
 		panic("ServerInterfaceMock.GetWithReferencesFunc: method is nil but ServerInterface.GetWithReferences was just called")
 	}
@@ -567,7 +568,7 @@ func (mock *ServerInterfaceMock) GetWithReferencesCalls() []struct {
 }
 
 // GetWithTaggedMiddleware calls GetWithTaggedMiddlewareFunc.
-func (mock *ServerInterfaceMock) GetWithTaggedMiddleware(w http.ResponseWriter, r *http.Request) Responser {
+func (mock *ServerInterfaceMock) GetWithTaggedMiddleware(w http.ResponseWriter, r *http.Request) render.Renderer {
 	if mock.GetWithTaggedMiddlewareFunc == nil {
 		panic("ServerInterfaceMock.GetWithTaggedMiddlewareFunc: method is nil but ServerInterface.GetWithTaggedMiddleware was just called")
 	}
@@ -603,7 +604,7 @@ func (mock *ServerInterfaceMock) GetWithTaggedMiddlewareCalls() []struct {
 }
 
 // PostWithTaggedMiddleware calls PostWithTaggedMiddlewareFunc.
-func (mock *ServerInterfaceMock) PostWithTaggedMiddleware(w http.ResponseWriter, r *http.Request) Responser {
+func (mock *ServerInterfaceMock) PostWithTaggedMiddleware(w http.ResponseWriter, r *http.Request) render.Renderer {
 	if mock.PostWithTaggedMiddlewareFunc == nil {
 		panic("ServerInterfaceMock.PostWithTaggedMiddlewareFunc: method is nil but ServerInterface.PostWithTaggedMiddleware was just called")
 	}
@@ -639,7 +640,7 @@ func (mock *ServerInterfaceMock) PostWithTaggedMiddlewareCalls() []struct {
 }
 
 // UpdateResource3 calls UpdateResource3Func.
-func (mock *ServerInterfaceMock) UpdateResource3(w http.ResponseWriter, r *http.Request, pFallthrough int) Responser {
+func (mock *ServerInterfaceMock) UpdateResource3(w http.ResponseWriter, r *http.Request, pFallthrough int) render.Renderer {
 	if mock.UpdateResource3Func == nil {
 		panic("ServerInterfaceMock.UpdateResource3Func: method is nil but ServerInterface.UpdateResource3 was just called")
 	}

--- a/internal/test/server/server_test.go
+++ b/internal/test/server/server_test.go
@@ -19,7 +19,7 @@ var noopMiddlewares = map[string]func(http.Handler) http.Handler{
 func TestParameters(t *testing.T) {
 	m := ServerInterfaceMock{}
 
-	m.CreateResource2Func = func(w http.ResponseWriter, r *http.Request, inlineArgument int, params CreateResource2Params) *Response {
+	m.CreateResource2Func = func(w http.ResponseWriter, r *http.Request, inlineArgument int, params CreateResource2Params) Responser {
 		assert.Equal(t, 99, *params.InlineQueryArgument)
 		assert.Equal(t, 1, inlineArgument)
 		return nil
@@ -66,7 +66,7 @@ func TestOmitMiddlewares(t *testing.T) {
 
 func TestMiddlewareCalled(t *testing.T) {
 	m := ServerInterfaceMock{}
-	m.GetWithTaggedMiddlewareFunc = func(w http.ResponseWriter, r *http.Request) *Response { return nil }
+	m.GetWithTaggedMiddlewareFunc = func(w http.ResponseWriter, r *http.Request) Responser { return nil }
 
 	called := false
 	mw := map[string]func(http.Handler) http.Handler{
@@ -89,7 +89,7 @@ func TestMiddlewareCalled(t *testing.T) {
 
 func TestMiddlewareCalledWithOrder(t *testing.T) {
 	m := ServerInterfaceMock{}
-	m.PostWithTaggedMiddlewareFunc = func(w http.ResponseWriter, r *http.Request) *Response { return nil }
+	m.PostWithTaggedMiddlewareFunc = func(w http.ResponseWriter, r *http.Request) Responser { return nil }
 
 	var order []string
 	mw := map[string]func(http.Handler) http.Handler{

--- a/internal/test/server/server_test.go
+++ b/internal/test/server/server_test.go
@@ -6,6 +6,7 @@ import (
 	"net/http/httptest"
 	"testing"
 
+	"github.com/go-chi/render"
 	"github.com/stretchr/testify/assert"
 )
 
@@ -19,7 +20,7 @@ var noopMiddlewares = map[string]func(http.Handler) http.Handler{
 func TestParameters(t *testing.T) {
 	m := ServerInterfaceMock{}
 
-	m.CreateResource2Func = func(w http.ResponseWriter, r *http.Request, inlineArgument int, params CreateResource2Params) Responser {
+	m.CreateResource2Func = func(w http.ResponseWriter, r *http.Request, inlineArgument int, params CreateResource2Params) render.Renderer {
 		assert.Equal(t, 99, *params.InlineQueryArgument)
 		assert.Equal(t, 1, inlineArgument)
 		return nil
@@ -66,7 +67,7 @@ func TestOmitMiddlewares(t *testing.T) {
 
 func TestMiddlewareCalled(t *testing.T) {
 	m := ServerInterfaceMock{}
-	m.GetWithTaggedMiddlewareFunc = func(w http.ResponseWriter, r *http.Request) Responser { return nil }
+	m.GetWithTaggedMiddlewareFunc = func(w http.ResponseWriter, r *http.Request) render.Renderer { return nil }
 
 	called := false
 	mw := map[string]func(http.Handler) http.Handler{
@@ -89,7 +90,7 @@ func TestMiddlewareCalled(t *testing.T) {
 
 func TestMiddlewareCalledWithOrder(t *testing.T) {
 	m := ServerInterfaceMock{}
-	m.PostWithTaggedMiddlewareFunc = func(w http.ResponseWriter, r *http.Request) Responser { return nil }
+	m.PostWithTaggedMiddlewareFunc = func(w http.ResponseWriter, r *http.Request) render.Renderer { return nil }
 
 	var order []string
 	mw := map[string]func(http.Handler) http.Handler{

--- a/templates/interface.tmpl
+++ b/templates/interface.tmpl
@@ -2,6 +2,6 @@
 type ServerInterface interface {
 	{{range .}}{{.SummaryAsComment }}
 	// ({{.Method}} {{.Path}})
-	{{.OperationID}}(w http.ResponseWriter, r *http.Request{{genParamArgs .PathParams}}{{if .RequiresParamObject}}, params {{.OperationID}}Params{{end}}) *Response
+	{{.OperationID}}(w http.ResponseWriter, r *http.Request{{genParamArgs .PathParams}}{{if .RequiresParamObject}}, params {{.OperationID}}Params{{end}}) Responser
 	{{end}}
 }

--- a/templates/interface.tmpl
+++ b/templates/interface.tmpl
@@ -2,6 +2,6 @@
 type ServerInterface interface {
 	{{range .}}{{.SummaryAsComment }}
 	// ({{.Method}} {{.Path}})
-	{{.OperationID}}(w http.ResponseWriter, r *http.Request{{genParamArgs .PathParams}}{{if .RequiresParamObject}}, params {{.OperationID}}Params{{end}}) Responser
+	{{.OperationID}}(w http.ResponseWriter, r *http.Request{{genParamArgs .PathParams}}{{if .RequiresParamObject}}, params {{.OperationID}}Params{{end}}) render.Renderer
 	{{end}}
 }

--- a/templates/middleware.tmpl
+++ b/templates/middleware.tmpl
@@ -158,6 +158,11 @@ func (siw *ServerInterfaceWrapper) {{$opid}}(w http.ResponseWriter, r *http.Requ
 	var handler = http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		resp := siw.Handler.{{.OperationID}}(w, r{{genParamNames .PathParams}}{{if .RequiresParamObject}}, params{{end}})
 		if resp != nil {
+			if resp, ok := resp.(Response); ok && resp.Body == nil {
+				w.WriteHeader(resp.Code)
+				return
+			}
+
 			render.Render(w, r, resp)
 		}
 	})

--- a/templates/middleware.tmpl
+++ b/templates/middleware.tmpl
@@ -158,10 +158,11 @@ func (siw *ServerInterfaceWrapper) {{$opid}}(w http.ResponseWriter, r *http.Requ
 	var handler = http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		resp := siw.Handler.{{.OperationID}}(w, r{{genParamNames .PathParams}}{{if .RequiresParamObject}}, params{{end}})
 		if resp != nil {
-		    if resp.body != nil {
-		        render.Render(w, r, resp)
+			rsp := resp.Response()
+			if rsp.Body != nil {
+		        render.Render(w, r, rsp)
 		    } else {
-				w.WriteHeader(resp.Code)
+				w.WriteHeader(rsp.Code)
 			}
 		}
 	})

--- a/templates/middleware.tmpl
+++ b/templates/middleware.tmpl
@@ -158,12 +158,7 @@ func (siw *ServerInterfaceWrapper) {{$opid}}(w http.ResponseWriter, r *http.Requ
 	var handler = http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		resp := siw.Handler.{{.OperationID}}(w, r{{genParamNames .PathParams}}{{if .RequiresParamObject}}, params{{end}})
 		if resp != nil {
-			rsp := resp.Response()
-			if rsp.Body != nil {
-		        render.Render(w, r, rsp)
-		    } else {
-				w.WriteHeader(rsp.Code)
-			}
+			render.Render(w, r, resp)
 		}
 	})
 

--- a/templates/response-bodies.tmpl
+++ b/templates/response-bodies.tmpl
@@ -1,18 +1,28 @@
 {{if .}}
 
+// Responser is an interface for responding to a request.
+type Responser interface {
+    Response() *Response
+}
+
 // Response is a common response struct for all the API calls.
 // A Response object may be instantiated via functions for specific operation responses.
 // It may also be instantiated directly, for the purpose of responding with a single status code.
 type Response struct {
-    body interface{}
+    Body interface{}
     Code int
-    contentType string
+    ContentType string
+}
+
+// Response implements the Responser interface.
+func (r *Response) Response() *Response {
+    return r
 }
 
 // Render implements the render.Renderer interface. It sets the Content-Type header
 // and status code based on the response definition.
 func (resp *Response) Render(w http.ResponseWriter, r *http.Request) error {
-    w.Header().Set("Content-Type", resp.contentType)
+    w.Header().Set("Content-Type", resp.ContentType)
     render.Status(r, resp.Code)
     return nil
 }
@@ -24,21 +34,21 @@ func (resp *Response) Status(code int) *Response {
 }
 
 // ContentType is a builder method to override the default content type for a response.
-func (resp *Response) ContentType(contentType string) *Response {
-    resp.contentType = contentType
+func (resp *Response) ContentTyp(contentType string) *Response {
+    resp.ContentType = contentType
     return resp
 }
 
 // MarshalJSON implements the json.Marshaler interface.
 // This is used to only marshal the body of the response.
 func (resp *Response) MarshalJSON() ([]byte, error) {
-    return json.Marshal(resp.body)
+    return json.Marshal(resp.Body)
 }
 
 // MarshalXML implements the xml.Marshaler interface.
 // This is used to only marshal the body of the response.
 func (resp *Response) MarshalXML(e *xml.Encoder, start xml.StartElement) error {
-	return e.Encode(resp.body)
+	return e.Encode(resp.Body)
 }
 
 {{end}}
@@ -50,9 +60,9 @@ func (resp *Response) MarshalXML(e *xml.Encoder, start xml.StartElement) error {
 // A *Response is returned with the configured status code and content type from the spec.
 func {{$opid | ucFirst}}{{.TypeName | title}}Response(body {{.Schema.TypeDecl}}) *Response {
     return &Response{
-            body: body,
+            Body: body,
             Code: {{.ResponseName | statusCode}},
-            contentType: "{{.ContentTypeName}}",
+            ContentType: "{{.ContentTypeName}}",
     }
 }
 

--- a/templates/response-bodies.tmpl
+++ b/templates/response-bodies.tmpl
@@ -1,10 +1,5 @@
 {{if .}}
 
-// Responser is an interface for responding to a request.
-type Responser interface {
-    Response() *Response
-}
-
 // Response is a common response struct for all the API calls.
 // A Response object may be instantiated via functions for specific operation responses.
 // It may also be instantiated directly, for the purpose of responding with a single status code.
@@ -14,29 +9,12 @@ type Response struct {
     ContentType string
 }
 
-// Response implements the Responser interface.
-func (r *Response) Response() *Response {
-    return r
-}
-
 // Render implements the render.Renderer interface. It sets the Content-Type header
 // and status code based on the response definition.
 func (resp *Response) Render(w http.ResponseWriter, r *http.Request) error {
     w.Header().Set("Content-Type", resp.ContentType)
     render.Status(r, resp.Code)
     return nil
-}
-
-// Status is a builder method to override the default status code for a response.
-func (resp *Response) Status(code int) *Response {
-    resp.Code = code
-    return resp
-}
-
-// ContentType is a builder method to override the default content type for a response.
-func (resp *Response) ContentTyp(contentType string) *Response {
-    resp.ContentType = contentType
-    return resp
 }
 
 // MarshalJSON implements the json.Marshaler interface.

--- a/templates/response-bodies.tmpl
+++ b/templates/response-bodies.tmpl
@@ -11,7 +11,7 @@ type Response struct {
 
 // Render implements the render.Renderer interface. It sets the Content-Type header
 // and status code based on the response definition.
-func (resp *Response) Render(w http.ResponseWriter, r *http.Request) error {
+func (resp Response) Render(w http.ResponseWriter, r *http.Request) error {
     w.Header().Set("Content-Type", resp.ContentType)
     render.Status(r, resp.Code)
     return nil
@@ -19,13 +19,13 @@ func (resp *Response) Render(w http.ResponseWriter, r *http.Request) error {
 
 // MarshalJSON implements the json.Marshaler interface.
 // This is used to only marshal the body of the response.
-func (resp *Response) MarshalJSON() ([]byte, error) {
+func (resp Response) MarshalJSON() ([]byte, error) {
     return json.Marshal(resp.Body)
 }
 
 // MarshalXML implements the xml.Marshaler interface.
 // This is used to only marshal the body of the response.
-func (resp *Response) MarshalXML(e *xml.Encoder, start xml.StartElement) error {
+func (resp Response) MarshalXML(e *xml.Encoder, start xml.StartElement) error {
 	return e.Encode(resp.Body)
 }
 
@@ -35,9 +35,9 @@ func (resp *Response) MarshalXML(e *xml.Encoder, start xml.StartElement) error {
 {{range getResponseTypeDefinitions .}}
 
 // {{$opid | ucFirst}}{{.TypeName | title}}Response is a constructor method for a {{$opid | ucFirst}} response.
-// A *Response is returned with the configured status code and content type from the spec.
-func {{$opid | ucFirst}}{{.TypeName | title}}Response(body {{.Schema.TypeDecl}}) *Response {
-    return &Response{
+// A Response is returned with the configured status code and content type from the spec.
+func {{$opid | ucFirst}}{{.TypeName | title}}Response(body {{.Schema.TypeDecl}}) Response {
+    return Response{
             Body: body,
             Code: {{.ResponseName | statusCode}},
             ContentType: "{{.ContentTypeName}}",


### PR DESCRIPTION
This PR adds a `Reponser` interface, which enables us to construct any form of custom type and turn them into responses accepted by goapi-gen.

The goal of this proposal is to shorten the error handling code, and clean up ugly multi-line errors made when constructing a non-standard/specified response body.

The example provided with the petstore may not be the best because of it's short nature, but we can easily save dozens of lines of code, and standardize better with such an API.