### PR TITLE
change enum MarshalJSON() method to not be called on ptr

### DIFF
--- a/templates/enum-typedef.tmpl
+++ b/templates/enum-typedef.tmpl
@@ -6,7 +6,7 @@ type {{.TypeName}} struct {
 func (t *{{.TypeName}}) ToValue() {{.Schema.TypeDecl}} {
     return t.value
 }
-func (t *{{.TypeName}}) MarshalJSON() ([]byte, error) {
+func (t {{.TypeName}}) MarshalJSON() ([]byte, error) {
     return json.Marshal(t.value)
 }
 func (t *{{.TypeName}}) UnmarshalJSON(data []byte) error {


### PR DESCRIPTION
We have a bug in the current enum rendering system where the `MarshalJSON` method is never called on pointer structs. This fixes this behavior (quiet easily).

```go
import (
	"encoding/json"
	"fmt"
)

type Enum struct {
	value string
}

type Enum2 struct {
	valie string
}

func (e Enum) MarshalJSON() ([]byte, error) {
	return []byte("\"another_value\""), nil
}

func (e *Enum2) MarshalJSON() ([]byte, error) {
	return []byte("\"another_value\""), nil
}

type Test struct {
	A Enum
	C Enum2
	B int
}

func main() {
	x := Test{
		A: Enum{},
		C: Enum2{},
		B: 1,
	}
	j, err := json.Marshal(x)
	if err != nil {
		panic(err)
	}
	fmt.Println(string(j))
}
```
Prints:
```
{"A":"another_value","C":{},"B":1}
```
Go playground example: https://go.dev/play/p/8QQzFwO9a-K